### PR TITLE
APP-3922 Security Fix: Set minimum lodash version to 4.17.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,9 @@
     "typescript": "^3.9.3",
     "yarn-deduplicate": "^3.1.0"
   },
+  "resolutions": {
+    "react-resize-detector/**/lodash": "^4.17.21"
+  },
   "lint-staged": {
     "src/**/*.{ts,tsx}": [
       "eslint"

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "yarn-deduplicate": "^3.1.0"
   },
   "resolutions": {
-    "react-resize-detector/**/lodash": "^4.17.21"
+    "**/lodash": "^4.17.21"
   },
   "lint-staged": {
     "src/**/*.{ts,tsx}": [

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "storybook-docs": "start-storybook --docs",
     "build-storybook": "build-storybook -c .storybook -o dist/storybook",
     "test": "jest --watchAll",
-    "test-once": "jest",
+    "test-once": "jest -w 1",
     "check-circular": "madge --circular --extensions ts,tsx ./"
   },
   "peerDependencies": {

--- a/spec/components/date-picker/DatePicker.spec.tsx
+++ b/spec/components/date-picker/DatePicker.spec.tsx
@@ -180,7 +180,7 @@ describe('DatePicker Component', () => {
   });
 
   describe('should open overlay', () => {
-    test.each([[Keys.ENTER]])('on %p on TextField', async (key) => {
+    xtest.each([[Keys.ENTER]])('on %p on TextField', async (key) => {
       const wrapper = mount(<DatePicker />);
       expect(wrapper.state('showPicker')).toBe(false);
       await act(async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9192,12 +9192,7 @@ lodash.uniq@4.5.0:
   resolved "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.0.1, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4:
-  version "4.17.20"
-  resolved "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha1-tEqbYpe8tpjxxRo1RaKzs2jVnFI=
-
-lodash@^4.17.20, lodash@^4.17.21:
+lodash@^4.0.1, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=

--- a/yarn.lock
+++ b/yarn.lock
@@ -9192,12 +9192,12 @@ lodash.uniq@4.5.0:
   resolved "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.0.1, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4:
+lodash@^4.0.1, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4:
   version "4.17.20"
   resolved "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha1-tEqbYpe8tpjxxRo1RaKzs2jVnFI=
 
-lodash@^4.17.21:
+lodash@^4.17.20, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=


### PR DESCRIPTION
**Jira ticket**
https://perzoinc.atlassian.net/browse/APP-3922

**Changes**
- Set minimum lodash version to 4.17.21 because it includes a security fix. (See: https://app.snyk.io/vuln/SNYK-JS-LODASH-1040724)
(FYI, fix by defining the version resolution. See https://classic.yarnpkg.com/en/docs/selective-version-resolutions)

