### PR TITLE
APP-4027 - Add right decorator props and deprecate masked prop

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -3,6 +3,8 @@ import addons from '@storybook/addons';
 import { addParameters, forceReRender } from '@storybook/react';
 import { themes } from '@storybook/theming';
 
+require('focus-visible');
+
 let globalDarkMode = undefined;
 
 setTimeout(() => init());

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -3,7 +3,7 @@ import addons from '@storybook/addons';
 import { addParameters, forceReRender } from '@storybook/react';
 import { themes } from '@storybook/theming';
 
-require('focus-visible');
+import 'focus-visible';
 
 let globalDarkMode = undefined;
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.4.4",
-    "@symphony/uitoolkit-styles": "1.3.6-SNAPSHOT.6",
+    "@symphony/uitoolkit-styles": "1.4.0",
     "@types/classnames": "^2.2.10",
     "classnames": "^2.2.6",
     "date-fns": "^2.16.1",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.20.0",
     "eslint-plugin-react-hooks": "^2.5.1",
+    "focus-visible": "^5.2.0",
     "html-react-parser": "^0.14.0",
     "husky": "^5.1.3",
     "jest": "^26.0.1",

--- a/spec/components/date-picker/DatePicker.spec.tsx
+++ b/spec/components/date-picker/DatePicker.spec.tsx
@@ -200,7 +200,7 @@ describe('DatePicker Component', () => {
       const wrapper = mount(<DatePicker />);
       expect(wrapper.state('showPicker')).toBe(false);
       await act(async () => {
-        wrapper.find('.tk-input').simulate('focus');
+        wrapper.find('.tk-input').simulate('click');
       });
 
       wrapper.update();

--- a/src/components/date-picker/DatePicker.tsx
+++ b/src/components/date-picker/DatePicker.tsx
@@ -484,7 +484,7 @@ class DatePicker extends Component<
             }
             value={inputValue || ''}
             onChange={this.handleInputChange}
-            onFocus={() => this.setState({ showPicker: true })}
+            onClick={() => this.setState({ showPicker: true })}
             onKeyDown={this.handleKeyDownInput}
           ></TextField>
         </div>

--- a/src/components/input/TextComponent.tsx
+++ b/src/components/input/TextComponent.tsx
@@ -139,7 +139,11 @@ const TextComponent: React.FC<TextComponentPropsWithType> = ({
         tooltipCloseLabel={tooltipCloseLabel}
         showRequired={showRequired}
       />
-      <div className="tk-input__container">
+      <div
+        className={classNames(className, 'tk-input__container', {
+          'tk-input__container--disabled': disabled,
+        })}
+      >
         <TagName
           id={id}
           aria-autocomplete="none"
@@ -148,9 +152,7 @@ const TextComponent: React.FC<TextComponentPropsWithType> = ({
           aria-placeholder={placeholder}
           aria-readonly={disabled}
           aria-multiline={type === Types.TEXTAREA}
-          className={classNames('tk-input', className, {
-            'tk-input--with-icon': iconElement,
-          })}
+          className={classNames('tk-input', /**className,**/)}
           placeholder={placeholder}
           value={value}
           onBlur={onBlur}
@@ -170,23 +172,10 @@ const TextComponent: React.FC<TextComponentPropsWithType> = ({
           disabled={disabled}
           {...rest}
         />
-        {iconElement && type == Types.TEXTFIELD
-          ? // Clone the iconElement in order to attach className 'tk-input__icon'
-            React.cloneElement(iconElement, {
-              className: classNames(
-                'tk-input__icon',
-                iconElement.props.className
-              ),
-            })
-          : null}
+
         {decoratorElement && type == Types.TEXTFIELD
           ? // Clone the decoratorElement in order to attach className 'tk-input__hide'
-            React.cloneElement(decoratorElement, {
-              className: classNames(
-                'tk-input__hide',
-                decoratorElement.props.className
-              ),
-            })
+            React.cloneElement(decoratorElement)
           : null}
         {type == Types.TEXTFIELD && masked && value?.length ? (
           <button
@@ -197,6 +186,15 @@ const TextComponent: React.FC<TextComponentPropsWithType> = ({
             {hideText ? 'show' : 'hide'}
           </button>
         ) : null}
+        {iconElement && type == Types.TEXTFIELD
+          ? // Clone the iconElement in order to attach className 'tk-input__icon'
+            React.cloneElement(iconElement, {
+              className: classNames(
+                'tk-input__icon',
+                iconElement.props.className
+              ),
+            })
+          : null}
       </div>
     </div>
   );

--- a/src/components/input/TextComponent.tsx
+++ b/src/components/input/TextComponent.tsx
@@ -187,12 +187,12 @@ const TextComponent: React.FC<TextComponentPropsWithType> = ({
         ) : null}
         {iconElement && type == Types.TEXTFIELD
           ? // Clone the iconElement in order to attach className 'tk-input__icon'
-            React.cloneElement(iconElement, {
-              className: classNames(
-                'tk-input__icon',
-                iconElement.props.className
-              ),
-            })
+          React.cloneElement(iconElement, {
+            className: classNames(
+              'tk-input__icon',
+              iconElement.props.className
+            ),
+          })
           : null}
       </div>
     </div>

--- a/src/components/input/TextComponent.tsx
+++ b/src/components/input/TextComponent.tsx
@@ -6,7 +6,7 @@ import shortid from 'shortid';
 
 import { HasValidationProps } from '../validation/interfaces';
 import { HasTooltipProps } from '../tooltip/interfaces';
-import LabelTooltipDecorator from '../label-tooltip-decorator/LabelTooltipDecorator'
+import LabelTooltipDecorator from '../label-tooltip-decorator/LabelTooltipDecorator';
 
 enum Types {
   TEXTAREA = 'TextArea',
@@ -17,14 +17,20 @@ export type InputBaseProps = {
   onCopy?: (event) => any;
   onCut?: (event) => any;
   onDrag?: (event) => any;
-}
+};
 
 type TextComponentProps = {
+  /** React Element to display inside of the Field, on the right side */
+  decoratorElement?: JSX.Element; // what do you think about the name?
   className?: string;
   disabled?: boolean;
+  /** React Element to display outside the Field, on the left side */
   iconElement?: JSX.Element;
   id?: string;
   label?: string;
+  /** Force the text to display masked "••••" */
+  isMasked?: boolean;
+  /** Deprecated, please use decoratorElement instead */
   masked?: boolean;
   placeholder?: string;
   onClick?: () => any;
@@ -32,23 +38,27 @@ type TextComponentProps = {
   onKeyDown?: (event) => any;
   value?: string;
   showRequired?: boolean;
-} & HasTooltipProps & HasValidationProps<string>;
+} & HasTooltipProps &
+  HasValidationProps<string>;
 
-type TextComponentPropsWithType = TextComponentProps & InputBaseProps & {
-  type: Types;
-};
+type TextComponentPropsWithType = TextComponentProps &
+  InputBaseProps & {
+    type: Types;
+  };
 
 export const InputBasePropTypes = {
   onCopy: PropTypes.func,
   onCut: PropTypes.func,
   onDrag: PropTypes.func,
-}
+};
 
 const TextComponentPropTypes = {
+  decoratorElement: PropTypes.element,
   className: PropTypes.string,
   disabled: PropTypes.bool,
   id: PropTypes.string,
   iconElement: PropTypes.element,
+  isMasked: PropTypes.bool,
   label: PropTypes.string,
   masked: PropTypes.bool,
   placeholder: PropTypes.string,
@@ -61,13 +71,15 @@ const TextComponentPropTypes = {
   tooltip: PropTypes.string,
   tooltipCloseLabel: PropTypes.string,
   value: PropTypes.string,
-  showRequired: PropTypes.bool
+  showRequired: PropTypes.bool,
 };
 
 const TextComponent: React.FC<TextComponentPropsWithType> = ({
+  decoratorElement,
   className,
   id,
   iconElement,
+  isMasked,
   type,
   disabled,
   label,
@@ -150,22 +162,33 @@ const TextComponent: React.FC<TextComponentPropsWithType> = ({
           style={
             {
               WebkitTextSecurity:
-                type == Types.TEXTFIELD && masked && hideText && 'disc',
+                type == Types.TEXTFIELD &&
+                (isMasked || (masked && hideText)) &&
+                'disc',
             } as React.CSSProperties
           }
           disabled={disabled}
           {...rest}
         />
         {iconElement && type == Types.TEXTFIELD
-          // Clone the iconElement in order to attach className 'tk-input__icon'
-          ? React.cloneElement(iconElement, {
-            className: classNames(
-              'tk-input__icon',
-              iconElement.props.className
-            ),
-          })
+          ? // Clone the iconElement in order to attach className 'tk-input__icon'
+            React.cloneElement(iconElement, {
+              className: classNames(
+                'tk-input__icon',
+                iconElement.props.className
+              ),
+            })
           : null}
-        {type == Types.TEXTFIELD && masked && value?.length && (
+        {decoratorElement && type == Types.TEXTFIELD
+          ? // Clone the decoratorElement in order to attach className 'tk-input__hide'
+            React.cloneElement(decoratorElement, {
+              className: classNames(
+                'tk-input__hide',
+                decoratorElement.props.className
+              ),
+            })
+          : null}
+        {type == Types.TEXTFIELD && masked && value?.length ? (
           <button
             className="tk-input__hide"
             tabIndex={value && value.length === 0 ? -1 : 0}
@@ -173,7 +196,7 @@ const TextComponent: React.FC<TextComponentPropsWithType> = ({
           >
             {hideText ? 'show' : 'hide'}
           </button>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/src/components/input/TextComponent.tsx
+++ b/src/components/input/TextComponent.tsx
@@ -20,17 +20,17 @@ export type InputBaseProps = {
 };
 
 type TextComponentProps = {
-  /** React Element to display inside of the Field, on the right side */
-  decoratorElement?: JSX.Element; // what do you think about the name?
+  /** React Element to display inside the Field, on the right side */
+  rightDecorators?: JSX.Element[];
   className?: string;
   disabled?: boolean;
-  /** React Element to display outside the Field, on the left side */
+  /** React Element to display inside the Field, on the left side */
   iconElement?: JSX.Element;
   id?: string;
   label?: string;
   /** Force the text to display masked "••••" */
   isMasked?: boolean;
-  /** Deprecated, please use decoratorElement instead */
+  /** Deprecated, please use rightDecorators instead */
   masked?: boolean;
   placeholder?: string;
   onClick?: () => any;
@@ -53,7 +53,7 @@ export const InputBasePropTypes = {
 };
 
 const TextComponentPropTypes = {
-  decoratorElement: PropTypes.element,
+  rightDecorators: PropTypes.array,
   className: PropTypes.string,
   disabled: PropTypes.bool,
   id: PropTypes.string,
@@ -75,7 +75,7 @@ const TextComponentPropTypes = {
 };
 
 const TextComponent: React.FC<TextComponentPropsWithType> = ({
-  decoratorElement,
+  rightDecorators,
   className,
   id,
   iconElement,
@@ -152,7 +152,7 @@ const TextComponent: React.FC<TextComponentPropsWithType> = ({
           aria-placeholder={placeholder}
           aria-readonly={disabled}
           aria-multiline={type === Types.TEXTAREA}
-          className={classNames('tk-input', /**className,**/)}
+          className={classNames('tk-input')}
           placeholder={placeholder}
           value={value}
           onBlur={onBlur}
@@ -173,9 +173,8 @@ const TextComponent: React.FC<TextComponentPropsWithType> = ({
           {...rest}
         />
 
-        {decoratorElement && type == Types.TEXTFIELD
-          ? // Clone the decoratorElement in order to attach className 'tk-input__hide'
-            React.cloneElement(decoratorElement)
+        {rightDecorators && type == Types.TEXTFIELD
+          ? rightDecorators.map((decorator) => decorator)
           : null}
         {type == Types.TEXTFIELD && masked && value?.length ? (
           <button

--- a/stories/TextField.stories.tsx
+++ b/stories/TextField.stories.tsx
@@ -139,17 +139,12 @@ export const TextFields: React.FC = () => {
           Simple Text Field with <strong>masked data</strong>
         </p>
         <TextField
-          value={value}
-          masked={true}
-          onChange={(e) => setValue(e.target.value)}
-        ></TextField>
-        <TextField
           isMasked={hideText}
           value={value}
           onChange={(e) => setValue(e.target.value)}
           decoratorElement={ value?.length ?
             <button
-              className="tk-input__hide"
+              className="tk-input__hide" // does the dev has to know that he needs to use this class?
               tabIndex={value && value.length === 0 ? -1 : 0}
               onClick={() => setHideText(!hideText)}
             >

--- a/stories/TextField.stories.tsx
+++ b/stories/TextField.stories.tsx
@@ -5,7 +5,7 @@ import { TextField, Icon, Validation } from '../src/components';
 import { Validators } from '../src/core/validators/validators';
 
 const Template = (args) => {
-  return   <TextField {...args}/>
+  return <TextField {...args} />;
 };
 
 export const Default = Template.bind({});
@@ -14,10 +14,12 @@ Default.args = {
   label: 'I have many props',
   tooltip: 'This is a tooltip \n with newline',
   tooltipCloseLabel: 'Got it',
-  iconElement: <Icon iconName="message"/>,
+  iconElement: <Icon iconName="message" />,
 };
 
 export const TextFields: React.FC = () => {
+  const [hideText, setHideText] = useState(false);
+
   const logChange = (value) => {
     console.info(value);
   };
@@ -136,7 +138,25 @@ export const TextFields: React.FC = () => {
         <p>
           Simple Text Field with <strong>masked data</strong>
         </p>
-        <TextField value="Lorem" masked={true} onChange={logChange}></TextField>
+        <TextField
+          value={value}
+          masked={true}
+          onChange={(e) => setValue(e.target.value)}
+        ></TextField>
+        <TextField
+          isMasked={hideText}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          decoratorElement={ value?.length ?
+            <button
+              className="tk-input__hide"
+              tabIndex={value && value.length === 0 ? -1 : 0}
+              onClick={() => setHideText(!hideText)}
+            >
+              {hideText ? 'show' : 'hide'}
+            </button>
+          : null}
+        ></TextField>
       </div>
     </div>
   );

--- a/stories/TextField.stories.tsx
+++ b/stories/TextField.stories.tsx
@@ -30,22 +30,22 @@ export const TextFields: React.FC = () => {
     <div style={{ width: '50%' }}>
       <div>
         <p>
-          Simple Text Field with a <strong>placeholder</strong>
+          Text Field with a <strong>placeholder</strong>
         </p>
         <TextField placeholder="Firstname"></TextField>
       </div>
       <hr />
       <div>
         <p>
-          Simple Text Field with a <strong>change handler</strong> logging in
-          the browser console
+          Text Field with a <strong>change handler</strong> logging in the
+          browser console
         </p>
         <TextField placeholder="Firstname" onChange={logChange}></TextField>
       </div>
       <hr />
       <div>
         <p>
-          Simple Text Field with a <strong>label</strong>
+          Text Field with a <strong>label</strong>
         </p>
         <p>
           {' '}
@@ -65,7 +65,8 @@ export const TextFields: React.FC = () => {
         </p>
         <p>
           {' '}
-          If the attribute showRequired is defined, the according style will be applied
+          If the attribute showRequired is defined, the according style will be
+          applied
         </p>
         <TextField
           id="input-1234567899"
@@ -77,14 +78,14 @@ export const TextFields: React.FC = () => {
       <hr />
       <div>
         <p>
-          Simple Text Field with an <strong>icon</strong>
+          Text Field with an <strong>icon</strong>
         </p>
         <TextField iconElement={<Icon iconName={'calendar'} />}></TextField>
       </div>
       <hr />
       <div>
         <p>
-          Simple Text Field with an <strong>icon</strong>, method{' '}
+          Text Field with an <strong>icon</strong>, method{' '}
           <strong>handlers</strong> and <strong>tabIndex</strong>
         </p>
         <TextField
@@ -101,7 +102,7 @@ export const TextFields: React.FC = () => {
       <hr />
       <div>
         <p>
-          Simple Text Field with a <strong>tooltip</strong>
+          Text Field with a <strong>tooltip</strong>
         </p>
         <TextField
           tooltip="More information"
@@ -112,7 +113,7 @@ export const TextFields: React.FC = () => {
       <hr />
       <div>
         <p>
-          Simple Text Field with a <strong>label</strong> and a{' '}
+          Text Field with a <strong>label</strong> and a{' '}
           <strong>tooltip</strong>
         </p>
         <TextField
@@ -125,7 +126,7 @@ export const TextFields: React.FC = () => {
       <hr />
       <div>
         <p>
-          Simple Text Field with a <strong>value</strong>
+          Text Field with a <strong>value</strong>
         </p>
         <TextField
           placeholder="Type something"
@@ -136,21 +137,48 @@ export const TextFields: React.FC = () => {
       <hr />
       <div>
         <p>
-          Simple Text Field with <strong>masked data</strong>
+          Text Field with a <strong>right decorator</strong> and{' '}
+          <strong>masked data</strong>
         </p>
         <TextField
           isMasked={hideText}
           value={value}
           onChange={(e) => setValue(e.target.value)}
-          decoratorElement={ value?.length ?
-            <button
-              className="tk-input__hide" // does the dev has to know that he needs to use this class?
-              tabIndex={value && value.length === 0 ? -1 : 0}
-              onClick={() => setHideText(!hideText)}
-            >
-              {hideText ? 'show' : 'hide'}
-            </button>
-          : null}
+          rightDecorators={
+            value?.length
+              ? [
+                <button
+                  key="button"
+                  className="tk-input__hide"
+                  tabIndex={value && value.length === 0 ? -1 : 0}
+                  onClick={() => setHideText(!hideText)}
+                >
+                  {hideText ? 'show' : 'hide'}
+                </button>,
+              ]
+              : null
+          }
+        ></TextField>
+      </div>
+      <div>
+        <p>
+          Text Field with other <strong>right decorators</strong>
+        </p>
+        <TextField
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          rightDecorators={
+            value?.length
+              ? [
+                <span key="span-copy" style={{ alignSelf: 'center', marginRight: '1rem' }}>
+                  <Icon iconName="copy"></Icon>
+                </span>,
+                <span key="span-search" style={{ alignSelf: 'center', marginRight: '1rem' }}>
+                  <Icon iconName="search"></Icon>
+                </span>,
+              ]
+              : null
+          }
         ></TextField>
       </div>
     </div>

--- a/stories/stories.scss
+++ b/stories/stories.scss
@@ -1,6 +1,6 @@
 html {
     font-family: 'SymphonyLato', 'Lato', 'Segoe UI', 'Helvetica Neue', 'Verdana', 'Arial', sans-serif;
-    font-size: 14px;
+    font-size: 16px;
 }
 
 // Layout utils

--- a/yarn.lock
+++ b/yarn.lock
@@ -2408,10 +2408,10 @@
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
 
-"@symphony/uitoolkit-styles@1.3.6-SNAPSHOT.6":
-  version "1.3.6-SNAPSHOT.6"
-  resolved "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/@symphony/uitoolkit-styles/-/@symphony/uitoolkit-styles-1.3.6-SNAPSHOT.6.tgz#b429b929989231984a5f34156a45ddbb007038f4"
-  integrity sha1-tCm5KZiSMZhKXzQVakXduwBwOPQ=
+"@symphony/uitoolkit-styles@1.4.0":
+  version "1.4.0"
+  resolved "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/@symphony/uitoolkit-styles/-/@symphony/uitoolkit-styles-1.4.0.tgz#207246b34544d3900f89d99c070c77d5e9951c1d"
+  integrity sha1-IHJGs0VE05APidmcBwx31emVHB0=
 
 "@testing-library/dom@^7.28.1", "@testing-library/dom@^7.29.0":
   version "7.29.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6887,6 +6887,11 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+focus-visible@^5.2.0:
+  version "5.2.0"
+  resolved "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/focus-visible/-/focus-visible-5.2.0.tgz#3a9e41fccf587bd25dcc2ef045508284f0a4d6b3"
+  integrity sha1-Op5B/M9Ye9JdzC7wRVCChPCk1rM=
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"


### PR DESCRIPTION
## Ticket
https://perzoinc.atlassian.net/browse/APP-4027

## Description & Demo
- Add new prop `decoratorElement`, the idea is to have the "masked" feature more generic and give the possibility to have something else
- New `isMasked` in order to force the TextField to show "••••••••"
- The `masked` attribute has been deprecated since it's a combination of `decoratorElement` and `isMasked`

![image](https://user-images.githubusercontent.com/56824367/114872146-521dc680-9dfa-11eb-8570-f4b8c35669e8.png)

## Storybook pages
![Apr-15-2021 13-04-56](https://user-images.githubusercontent.com/56824367/114859581-3ced6b80-9deb-11eb-9e9f-5aafeb8ed142.gif)
![Apr-15-2021 13-05-01](https://user-images.githubusercontent.com/56824367/114859606-4676d380-9deb-11eb-9b5e-f31c24b88b95.gif)

## PR related
Styles https://github.com/SymphonyPlatformSolutions/symphony-bdk-ui-toolkit-styles/pull/80
