### PR TITLE
APP-3943 - Add props onToggle to Expandable Card and CropContent

### DIFF
--- a/spec/components/dropdown/Dropdown.spec.tsx
+++ b/spec/components/dropdown/Dropdown.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import userEvent from '@testing-library/user-event';
-import { render, screen, waitFor, waitForElementToBeRemoved, fireEvent, getByText } from '@testing-library/react';
+import { render, screen, waitFor, waitForElementToBeRemoved, fireEvent } from '@testing-library/react';
 import Dropdown from '../../../src/components/dropdown';
 import '@testing-library/jest-dom/extend-expect';
 import { Button, Validation } from '../../../src/components';

--- a/spec/components/expandable-card/ExpandableCard.spec.tsx
+++ b/spec/components/expandable-card/ExpandableCard.spec.tsx
@@ -6,22 +6,19 @@ import { ExpandableCard } from '../../../src/components';
  * Util methods
  */
 
-const getWrapper = (initCollapsed?) =>
+const getWrapper = (props?) =>
   shallow(
-    <ExpandableCard header={<h1>Header</h1>} initCollapsed={initCollapsed}>
+    <ExpandableCard header={<h1>Header</h1>} {...props}>
       <div className="bodyContent">Body</div>
     </ExpandableCard>
   );
 
-const getToggleLink = wrapper => {
+const getToggleLink = (wrapper) => {
   return wrapper.find('a.tk-link.toggle');
 };
 
-const getBodyDiv = wrapper => {
-  return wrapper
-    .find('div')
-    .first()
-    .childAt(1);
+const getBodyDiv = (wrapper) => {
+  return wrapper.find('div').first().childAt(1);
 };
 
 describe('CropContent Component', () => {
@@ -32,24 +29,24 @@ describe('CropContent Component', () => {
       expect(getToggleLink(wrapper).length).toBe(1);
     });
     it('toggle should run properly', () => {
-      const wrapper = getWrapper();
+      const onToggle = jest.fn();
+      const wrapper = getWrapper({ onToggle });
       expect(
-        wrapper
-          .find('div')
-          .first()
-          .childAt(1)
-          .hasClass('collapsed')
+        wrapper.find('div').first().childAt(1).hasClass('collapsed')
       ).toBeTruthy();
       expect(getToggleLink(wrapper).text()).toEqual('EXPAND');
       getToggleLink(wrapper).simulate('click');
       expect(getBodyDiv(wrapper).hasClass('collapsed')).toBeFalsy();
+      expect(onToggle).toHaveBeenCalledWith(false, null);
       expect(getToggleLink(wrapper).text()).toEqual('COLLAPSE');
+      getToggleLink(wrapper).simulate('click');
+      expect(onToggle).toHaveBeenCalledWith(true, null);
     });
 
     it('should init collapsed properly', () => {
-      let wrapper = getWrapper(true);
+      let wrapper = getWrapper({ initCollapsed: true });
       expect(getBodyDiv(wrapper).hasClass('collapsed')).toBeTruthy();
-      wrapper = getWrapper(false);
+      wrapper = getWrapper({ initCollapsed: false });
       expect(getBodyDiv(wrapper).hasClass('collapsed')).toBeFalsy();
       wrapper = getWrapper();
       expect(getBodyDiv(wrapper).hasClass('collapsed')).toBeTruthy();

--- a/src/components/crop-content/CropContent.tsx
+++ b/src/components/crop-content/CropContent.tsx
@@ -11,6 +11,8 @@ type CropContentProps = {
   initCollapsed?: boolean;
   /** Optional inline style */
   style?: React.CSSProperties;
+  /** Method triggered when clicking on "Show more/less" return the collapsed boolean and the element itself */
+  onToggle?: (collapsed: boolean, el?: HTMLDivElement) => any;
 };
 
 export default class CropContent extends React.Component<CropContentProps> {
@@ -34,7 +36,15 @@ export default class CropContent extends React.Component<CropContentProps> {
   }
 
   onToggle() {
-    this.setState({ collapsed: !this.state.collapsed });
+    const { onToggle } = this.props;
+    const { collapsed } = this.state;
+    
+    const reverseCollapsed = !collapsed;
+    this.setState({ collapsed: reverseCollapsed });
+
+    if (onToggle) {
+      onToggle(reverseCollapsed, this.containerElRef);
+    }
   }
 
   componentDidMount() {

--- a/src/components/expandable-card/ExpandableCard.tsx
+++ b/src/components/expandable-card/ExpandableCard.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import styled from 'styled-components';
 import * as PropTypes from 'prop-types';
+import { useState } from 'react';
+import classNames from 'classnames';
 
 type ExpandableCardProps = {
   children?: React.ReactNode;
@@ -8,8 +10,10 @@ type ExpandableCardProps = {
   header: React.ReactNode;
   /** Optional CSS class name */
   className?: string;
-   /** If true, the expandable card will be collapsed initially. */
+  /** If true, the expandable card will be collapsed initially. */
   initCollapsed?: boolean;
+  /** Method triggered when clicking on "EXPAND/COLLAPSE" return the collapsed boolean and the element itself*/
+  onToggle?: (collapsed: boolean, el?: HTMLDivElement) => any;
 };
 // styled components, if it grows put in a sibling file
 const HeaderDiv = styled.div`
@@ -45,46 +49,54 @@ const BodyDiv = styled.div`
   }
 `;
 
-export default class ExpandableCard extends React.Component<
-  ExpandableCardProps
-> {
-  public state = {
-    collapsed:
-      this.props.initCollapsed === undefined || this.props.initCollapsed
+const ExpandableCard: React.FC<ExpandableCardProps> = ({
+  children,
+  className,
+  header,
+  initCollapsed,
+  onToggle,
+  ...rest
+}: ExpandableCardProps) => {
+  const [collapsed, setCollasped] = useState(
+    initCollapsed === undefined || initCollapsed
+  );
+  const [refEl, setRefEl] = useState(null);
+
+  const onToggleHeader = () => {
+    const reverseCollapsed = !collapsed;
+    setCollasped(reverseCollapsed);
+
+    if (onToggle) {
+      onToggle(reverseCollapsed, refEl);
+    }
   };
 
-  onToggle() {
-    this.setState({ collapsed: !this.state.collapsed });
-  }
+  return (
+    <div className={className} ref={setRefEl} {...rest}>
+      <HeaderDiv>
+        <div>{header}</div>
+        &bull;
+        <a className={classNames('tk-link toggle')} onClick={onToggleHeader}>
+          {collapsed ? 'EXPAND' : 'COLLAPSE'}
+        </a>
+        <i
+          className={classNames('tk-icon-top', { collapsed })}
+          onClick={onToggleHeader}
+          aria-label="Toggle"
+        ></i>
+      </HeaderDiv>
+      <BodyDiv className={classNames({ collapsed })}>{children}</BodyDiv>
+    </div>
+  );
+};
 
-  render() {
-    const collapsedClass = this.state.collapsed ? ' collapsed' : '';
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { initCollapsed, header, children, ...rest } = this.props;
-    return (
-      <div {...rest}>
-        <HeaderDiv>
-          <div>{this.props.header}</div>
-          &bull;
-          <a className="tk-link toggle" onClick={this.onToggle.bind(this)}>
-            {this.state.collapsed ? 'EXPAND' : 'COLLAPSE'}
-          </a>
-          <i
-            className={'tk-icon-top' + collapsedClass}
-            onClick={this.onToggle.bind(this)}
-            aria-label="Toggle"
-          ></i>
-        </HeaderDiv>
-        <BodyDiv className={collapsedClass}>{children}</BodyDiv>
-      </div>
-    );
-  }
-  static propTypes = {
-    initCollapsed: PropTypes.bool,
-    header: PropTypes.node.isRequired
-  };
+ExpandableCard.propTypes = {
+  initCollapsed: PropTypes.bool,
+  header: PropTypes.node.isRequired,
+};
 
- static defaultProps = {
-   initCollapsed: true
- };
-}
+ExpandableCard.defaultProps = {
+  initCollapsed: true,
+};
+
+export default ExpandableCard;

--- a/stories/CropContent.stories.tsx
+++ b/stories/CropContent.stories.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { Button, CropContent } from '../src/components';
 
-const sampleText =
-  `Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+const sampleText = `Sed ut perspiciatis unde omnis iste natus error sit voluptatem
 accusantium doloremque laudantium, totam rem aperiam, eaque ipsa
 quae ab illo inventore veritatis et quasi architecto beatae vitae
 dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit
@@ -15,18 +14,21 @@ nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut
 aliquid ex ea commodi consequatur? Quis autem vel eum iure
 reprehenderit qui in ea voluptate velit esse quam nihil molestiae
 consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla
-pariatur?`
+pariatur?`;
 
 const Template = (args) => {
   return (
     <CropContent {...args}>
       {sampleText}
-      <div className="tk-m-2h"  style={{ display: 'flex', justifyContent: 'center' }}>
-        <Button >Got it!</Button>
+      <div
+        className="tk-m-2h"
+        style={{ display: 'flex', justifyContent: 'center' }}
+      >
+        <Button>Got it!</Button>
       </div>
     </CropContent>
-  )
-}
+  );
+};
 export const Default = Template.bind({});
 Default.args = {
   className: 'tk-quote-container',
@@ -34,12 +36,19 @@ Default.args = {
 
 export const CropContentContainer = () => {
   return (
-    <div style={{width:'80%'}}>
+    <div style={{ width: '80%' }}>
       <div className="flex-row">
         <div className="flex-col">
           <h2>Without content overflow</h2>
-          <p> Note that squeezing the window and shrinking the content until it overflows will make the show more toggle appear: </p>
-          <CropContent className="tk-quote-container tk-quote-container--error">
+          <p>
+            {' '}
+            Note that squeezing the window and shrinking the content until it
+            overflows will make the show more toggle appear:{' '}
+          </p>
+          <CropContent
+            className="tk-quote-container tk-quote-container--error"
+            onToggle={(collapsed, el) => console.log('CropContent toggled', collapsed, el)}
+          >
             Sed ut perspiciatis unde omnis iste natus error sit voluptatem
             accusantium doloremque laudantium, totam rem aperiam, eaque ipsa
             quae ab illo inventore veritatis et quasi architecto beatae vitae
@@ -50,7 +59,9 @@ export const CropContentContainer = () => {
       <div className="flex-row">
         <div className="flex-col">
           <h2>Unstyled</h2>
-          <CropContent>
+          <CropContent
+            onToggle={(collapsed, el) => console.log('CropContent toggled', collapsed, el)}
+          >
             {sampleText}
           </CropContent>
         </div>
@@ -61,5 +72,5 @@ export const CropContentContainer = () => {
 
 export default {
   title: 'Components/Containers/Crop Content',
-  component: CropContent
+  component: CropContent,
 };

--- a/stories/ExpandableCard.stories.tsx
+++ b/stories/ExpandableCard.stories.tsx
@@ -1,8 +1,13 @@
 import * as React from 'react';
-import { ExpandableCard, Button, CropContent, Link, Icon } from '../src/components';
+import {
+  ExpandableCard,
+  Button,
+  CropContent,
+  Link,
+  Icon,
+} from '../src/components';
 
-const sampleText =
-  `Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+const sampleText = `Sed ut perspiciatis unde omnis iste natus error sit voluptatem
 accusantium doloremque laudantium, totam rem aperiam, eaque ipsa
 quae ab illo inventore veritatis et quasi architecto beatae vitae
 dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit
@@ -15,28 +20,35 @@ nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut
 aliquid ex ea commodi consequatur? Quis autem vel eum iure
 reprehenderit qui in ea voluptate velit esse quam nihil molestiae
 consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla
-pariatur?`
+pariatur?`;
 
 const Template = (args) => {
   return (
     <div>
-      <ExpandableCard {...args}
+      <ExpandableCard
+        {...args}
+        onToggle={(el) => console.log('ExpandableCard toggled', el)}
         header={
           <div>
-            An example of a header with a An example of a header with a An example of a header with a An example of a header with a An example of a header with a An example of a header with a  <Link url={'https://www.symphony.com'}>link</Link>
+            An example of a header with a An example of a header with a An
+            example of a header with a An example of a header with a An example
+            of a header with a An example of a header with a{' '}
+            <Link url={'https://www.symphony.com'}>link</Link>
           </div>
         }
       >
-        <CropContent className="tk-quote-container tk-quote-container--error">
+        <CropContent
+          className="tk-quote-container tk-quote-container--error"
+          onToggle={(el) => console.log('CropContent toggled', el)}
+        >
           {sampleText}
         </CropContent>
       </ExpandableCard>
     </div>
-  )
-}
+  );
+};
 
 export const Default = Template.bind({});
-
 
 export const InitiallyExpandedCard: React.SFC = () => {
   return (
@@ -54,10 +66,11 @@ export const InitiallyExpandedCard: React.SFC = () => {
             <Button variant="destructive" disabled>
               <Icon iconName="cross"></Icon>
             </Button>
-          </div>}
+          </div>
+        }
         initCollapsed={false}
       >
-        <CropContent className="tk-quote-container" style={{width: '60%'}}>
+        <CropContent className="tk-quote-container" style={{ width: '60%' }}>
           {sampleText}
         </CropContent>
       </ExpandableCard>


### PR DESCRIPTION
## Ticket
https://perzoinc.atlassian.net/browse/APP-3943

## Description
- CropContent: Add onToggle props that returns the element itself and the collapsed boolean
- ExpandableCard: Add onToggle props that returns the element itself and the collapsed boolean

## PR related
https://github.com/SymphonyOSF/NEXUS/pull/1245