### PR TITLE
APP-3937 feat(dropdown): create nested mode

### DIFF
--- a/src/components/dropdown/CustomRender.tsx
+++ b/src/components/dropdown/CustomRender.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import classNames from 'classnames';
 import { components } from 'react-select';
 import Icon from '../icon';
 import { SearchHeaderOption } from './interfaces';
@@ -17,7 +18,7 @@ const stopPropagation = (e) => {
  * the appereace of the react-select library components **/
 
 export const DefaultOptionRenderer = (props: any) => {
-  const { enableTermSearch, inputValue } = props?.selectProps;
+  const { classNamePrefix, enableTermSearch, inputValue, mode } = props?.selectProps;
   const OptionRenderer = props?.selectProps?.optionRenderer;
   const isSelected = props.isSelected;
   const isSearchHeaderOption = props?.data?.searchHeader;
@@ -51,7 +52,7 @@ export const DefaultOptionRenderer = (props: any) => {
         </div>
       ) : (
         <div className="tk-option">
-          <components.Option {...props} />
+          <components.Option {...props} className={classNames(classNamePrefix && mode ? `${classNamePrefix}__option--${mode}` : null)}/>
         </div>
       )}
     </>

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -29,87 +29,90 @@ import LabelTooltipDecorator from '../label-tooltip-decorator/LabelTooltipDecora
 const prefix = 'tk-select';
 
 export type DropdownProps<T> = {
+  /** Allows to scroll automatically to selected option */
+  autoScrollToCurrent?: boolean;
+  /** Path in custom object to the unique identifier of the option */
+  bindValue?: string;
+  /** Blur the field when an item is selected */
+  blurInputOnSelect?: boolean;
+  /** Optional CSS class name */
+  className?: string;
+  /** Close the expanded menu when the user selects an option */
+  closeMenuOnSelect?: boolean;
+  /** Enables the indicator to expand the Dropdown */
+  displayArrowIndicator?: boolean;
+  /** Display a fixed option on the header of the Dropdown with the searched term */
+  enableTermSearch?: boolean;
+  /** Decides if an item with data and current input value should be displayed in dropdown menu or not */
+  filterFunction?: (data: T, inputValue: string) => boolean;
+  /** Hide the selected option from the list */
+  hideSelectedOptions?: boolean;
+  /** If provided, it renders an icon on the left side of the dropdown input*/
+  iconName?: string;
+  id?: string;
+  /** If provided, it decides if the input should always be displayed even if the option is selected*/
+  inputAlwaysDisplayed?: boolean;
+  /** The value of the search input */
+  inputValue?: string;
+  /** Is the select value clearable */
+  isInputClearable?: boolean;
+  /** If false, user can not type on the control Input */
+  isTypeAheadEnabled?: boolean;
+  /** Decides if an item with data and current input value should be disabled in dropdown menu or not */
+  isOptionDisabled?: (data: T) => boolean;
+  /** Decides if an item with data and current input value should be selected in dropdown menu or not */
+  isOptionSelected?: (data: T) => boolean;
+  /** Is the dropdown disabled */
+  isDisabled?: boolean;
+  /** Label text for the dropdown */
+  label?: string;
+  /** Maximum height of the menu before scrolling */
+  maxMenuHeight?: number;
+  /** Max height of the select input before scrolling */
+  maxHeight?: number;
+  /** Whether the Dropdown menu is expanded */
+  menuIsOpen?: boolean;
+  /** Styling options depending on the need  */
+  mode?: 'nested' | 'aligned';
+  name?: string;
+  /** Mesage to display if there isn't any match in the search input */
+  noOptionMessage?: string;
+  /** Placeholder text for the dropdown */
+  placeHolder?: string;
   /** Array of options that populate the dropdown menu */
   options: DropdownOption<T>[];
   /** Custom component used to override the default appearance of the list items. */
   optionRenderer?:
     | React.Component<OptionRendererProps<T>, any>
     | React.FunctionComponent<OptionRendererProps<T>>;
-  /** Custom component used to override the default appearance of the dropdown select input item/s */
-  tagRenderer?:
-    | React.Component<TagRendererProps<T>, any>
-    | React.FunctionComponent<TagRendererProps<T>>;
   /** Handle blur events on the control */
   onBlur?: (e) => any;
-  /** Decides if an item with data and current input value should be displayed in dropdown menu or not */
-  filterFunction?: (data: T, inputValue: string) => boolean;
-  /** Decides if an item with data and current input value should be disabled in dropdown menu or not */
-  isOptionDisabled?: (data: T) => boolean;
-  /** Decides if an item with data and current input value should be selected in dropdown menu or not */
-  isOptionSelected?: (data: T) => boolean;
-  /** If provided, it renders an icon on the left side of the dropdown input*/
-  iconName?: string;
-  /** If provided, it decides if the input should always be displayed even if the option is selected*/
-  inputAlwaysDisplayed?: boolean;
-  /** Mesage to display if there isn't any match in the search input */
-  noOptionMessage?: string;
-  /** Is the dropdown disabled */
-  isDisabled?: boolean;
-  /** Placeholder text for the dropdown */
-  placeHolder?: string;
-  /** Label text for the dropdown */
-  label?: string;
-  /** If false, user can not type on the control Input */
-  isTypeAheadEnabled?: boolean;
-  /** Enables the indicator to expand the Dropdown */
-  displayArrowIndicator?: boolean;
-  /** Default value selected on the Dropdown */
-  id?: string;
-  name?: string;
-  /** Optional CSS class name */
-  className?: string;
-  /** Close the expanded menu when the user selects an option */
-  closeMenuOnSelect?: boolean;
-  /** Hide the selected option from the list */
-  hideSelectedOptions?: boolean;
-  /** Is the select value clearable */
-  isInputClearable?: boolean;
-  /** The value of the search input */
-  inputValue?: string;
-  /** Maximum height of the menu before scrolling */
-  maxMenuHeight?: number;
-  /** Max height of the select input before scrolling */
-  maxHeight?: number;
-  /** Allows to scroll automatically to selected option */
-  autoScrollToCurrent?: boolean;
   /** Handle key down events on the select */
   onKeyDown?: (event) => any;
   /** Handle key up events on the select */
   onKeyUp?: (event) => any;
   /** Handle change events on the input */
   onInputChange?: (string, any) => any;
-  /** Whether the Dropdown menu is expanded */
-  menuIsOpen?: boolean;
-  /** Handle focus events */
+  /** Handle clear event */
+  onClear?: () => any;
+  /** Handle focus event */
   onFocus?: (event) => any;
   /** Handle the menu opening */
   onMenuOpen?: () => void;
   /** Handle the menu closing */
   onMenuClose?: () => void;
-  /** Select the currently focused option when the user presses tab */
-  tabSelectsValue?: boolean;
-  /** Display a fixed option on the header of the Dropdown with the searched term */
-  enableTermSearch?: boolean;
-  /** Message to be display on the header of the menu list when searching by term */
-  termSearchMessage?: ((term: string) => string) | string;
   /** Handle the selection of search by term option */
   onTermSearch?: (option: SearchHeaderOption) => any;
-  onClear?: () => any;
-  blurInputOnSelect?: boolean;
-  /** Path in custom object to the unique identifier of the option */
-  bindValue?: string;
   /** Flag to show the label with a specific styling if the field is required */
   showRequired?: boolean;
+  /** Select the currently focused option when the user presses tab */
+  tabSelectsValue?: boolean;
+  /** Custom component used to override the default appearance of the dropdown select input item/s */
+  tagRenderer?:
+    | React.Component<TagRendererProps<T>, any>
+    | React.FunctionComponent<TagRendererProps<T>>;
+  /** Message to be display on the header of the menu list when searching by term */
+  termSearchMessage?: ((term: string) => string) | string;
 } & HasTooltipProps &
   (MultiModeProps<T> | SingleModeProps<T>);
 
@@ -228,39 +231,40 @@ export class Dropdown<T = LabelValue> extends React.Component<
       displayArrowIndicator,
     } = this.state;
     const {
-      isMultiSelect,
-      isDisabled,
-      placeHolder,
-      id,
-      name,
+      autoScrollToCurrent,
+      blurInputOnSelect,
       defaultValue,
+      enableTermSearch,
+      iconName,
+      id,
+      inputAlwaysDisplayed,
+      inputValue,
+      isDisabled,
+      isInputClearable,
+      isMultiSelect,
+      isTypeAheadEnabled,
+      label,
+      maxHeight,
+      maxMenuHeight,
+      menuIsOpen,
+      mode,
+      name,
+      noOptionMessage,
+      placeHolder,
       onFocus,
       onInputChange,
       onKeyDown,
       onKeyUp,
-      isInputClearable,
-      label,
-      optionRenderer,
-      iconName,
-      inputAlwaysDisplayed,
-      tagRenderer,
-      value,
-      inputValue,
-      noOptionMessage,
-      isTypeAheadEnabled,
-      autoScrollToCurrent,
-      maxMenuHeight,
-      menuIsOpen,
-      tooltip,
-      tooltipCloseLabel,
       onMenuOpen,
       onMenuClose,
-      tabSelectsValue,
-      enableTermSearch,
-      termSearchMessage,
-      blurInputOnSelect,
+      optionRenderer,
+      tagRenderer,
+      tooltip,
+      tooltipCloseLabel,
       showRequired, 
-      maxHeight,
+      tabSelectsValue,
+      termSearchMessage,
+      value,
     } = this.props;
 
     return (
@@ -326,6 +330,7 @@ export class Dropdown<T = LabelValue> extends React.Component<
           isOptionSelected={this.handleIsOptionSelected}
           menuPlacement="auto"
           maxMenuHeight={maxMenuHeight}
+          mode={mode ? mode : 'aligned'}
           autoScrollToCurrent={autoScrollToCurrent}
           menuIsOpen={menuIsOpen}
           onMenuOpen={onMenuOpen}

--- a/stories/Dropdown.stories.tsx
+++ b/stories/Dropdown.stories.tsx
@@ -155,7 +155,10 @@ export const Select: React.FC = () => (
     </p>
     <Dropdown options={defaultOptions} iconName="app"/>
     <h3 className="tk-mt-4">Grouped option list</h3>
-    <Dropdown options={timeZoneOptions} />
+    <p>With <b>aligned</b> mode (default)</p>
+    <Dropdown options={timeZoneOptions} mode="aligned"/>
+    <p>With <b>nested</b> mode</p>
+    <Dropdown options={timeZoneOptions} mode="nested"/>
 
     <h2 className="tk-mt-4">Enable term search</h2>
     <p>- With <Typography variant="bold">enableTermSearch</Typography> prop activated you can add a fixed option on the header of the Dropdown Menu that will be displayed when the user starts typing.</p>
@@ -209,6 +212,6 @@ export const Select: React.FC = () => (
 );
 
 export default {
-  title: 'Components/Input/Dropdown (beta)',
+  title: 'Components/Input/Dropdown',
   component: Dropdown
 };


### PR DESCRIPTION
## Ticket 
https://perzoinc.atlassian.net/browse/APP-3931

## Approach
Create a `mode` prop that can be either nested (or aligned)
- The nested is only applied on the default render
- We don't do anything special in "aligned" mode

Bonus: Reorder the props

## Question
What do you think about the implementation

## Styles PR
https://github.com/SymphonyPlatformSolutions/symphony-bdk-ui-toolkit-styles/pull/90

## Demo
<img width="631" alt="Screenshot 2021-05-24 at 14 31 54" src="https://user-images.githubusercontent.com/56824367/119348346-08e45080-bc9d-11eb-843c-355133304141.png">
