### PR TITLE
APP-4177 Set v4.3.1 as the minimum version of react-select

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-cool-onclickoutside": "^1.5.8",
     "react-popper": "^2.2.3",
     "react-resize-detector": "^5.0.3",
-    "react-select": "^4.0.0",
+    "react-select": "^4.3.1",
     "react-transition-group": "^4.4.1",
     "react-virtualized": "^9.22.2",
     "shortid": "^2.2.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10557,7 +10557,7 @@ react-resize-detector@^5.0.3:
     raf-schd "^4.0.2"
     resize-observer-polyfill "^1.5.1"
 
-react-select@^4.0.0:
+react-select@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/react-select/-/react-select-4.3.1.tgz#389fc07c9bc7cf7d3c377b7a05ea18cd7399cb81"
   integrity sha512-HBBd0dYwkF5aZk1zP81Wx5UsLIIT2lSvAY2JiJo199LjoLHoivjn9//KsmvQMEFGNhe58xyuOITjfxKCcGc62Q==


### PR DESCRIPTION
**Jira**
https://perzoinc.atlassian.net/browse/APP-4177

**Changes**
Version 4.3.1 was already used in the yarn.lock, but to be sure we also define v4.3.1 as the minimum version of react-select in the package.json.

(To always have the fix of React-Select: https://github.com/JedWatson/react-select/releases/tag/react-select%404.3.1)