### PR TITLE
APP-4242 - Tooltip : Wrap the children in a span

### DIFF
--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -104,13 +104,15 @@ const Tooltip: React.FC<TooltipProps> = ({
       },
     ],
   });
+  
+  const children = <span>{otherProps.children}</span>
 
   return (
     <div ref={ref} className={otherProps.className ? otherProps.className + '_wrapper' : null}>
       <SpanStyled ref={setReferenceElement}>
-        { displayTrigger === 'hover' && showTooltipOnHover(otherProps.children, setShowHover) }
-        { displayTrigger === 'click' && showTooltipOnClick(otherProps.children, showClick, setShowClick) }
-        { displayTrigger === undefined && otherProps.children }
+        { displayTrigger === 'hover' && showTooltipOnHover(children, setShowHover) }
+        { displayTrigger === 'click' && showTooltipOnClick(children, showClick, setShowClick) }
+        { displayTrigger === undefined && children }
         <CSSTransition
           {...popperProps}
           in={visible || showHover || showClick}

--- a/stories/Tooltip.stories.tsx
+++ b/stories/Tooltip.stories.tsx
@@ -90,9 +90,7 @@ OnClick.decorators = [addExplanation('Click the icon to see the tooltip')];
 export const OnHover = (args) => {
   return (
     <Tooltip {...args}>
-      <span>
-        <Icon iconName="info-round" />
-      </span>
+      <Icon iconName="info-round" />
     </Tooltip>
   );
 };


### PR DESCRIPTION
## Ticket
https://perzoinc.atlassian.net/browse/APP-4242

## Description
From bug explained here: 

https://user-images.githubusercontent.com/56824367/122567353-dd107c80-d048-11eb-9a26-cc689d7489f7.mov

https://perzoinc.atlassian.net/wiki/spaces/EIS/pages/1953630703/Weekly+status+meeting+minutes#issue-tooltip-%2F-Switch-disabled
The resolution is to wrap the children inside a span, a solution is to add it directly to the general component, so the workaround doesn't need to be added by the consumer

