### PR TITLE
APP-4195 Send additional attributes to the ModalTitle/ModalHeader/ModalBody/ModalFooter

### DIFF
--- a/spec/components/modal/Modal.spec.tsx
+++ b/spec/components/modal/Modal.spec.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { mount } from 'enzyme';
-import { Modal } from '../../../src/components';
-import { ModalBody, ModalHeader } from '../../../src/components/modal/Modal';
+import { Modal, ModalBody, ModalFooter, ModalHeader, ModalTitle } from '../../../src/components';
 import { Keys } from '../../../src/components/common/keyUtils';
 
 import {
@@ -12,31 +10,78 @@ import {
 
 describe('Modal', () => {
   it('should render the content with correct class and without crash', () => {
-    const wrapper = mount(
-      <Modal size={'small'} show>
-        <ModalHeader>Hello, World</ModalHeader>
-        <ModalBody>Some text</ModalBody>
-      </Modal>
-    );
-    expect(wrapper.find('Modal').length).toBe(1);
-    expect(wrapper.children().hasClass('tk-dialog-backdrop')).toBe(true);
-    expect(wrapper.children().children().hasClass('tk-dialog tk-dialog--small')).toBe(true);
-    expect(wrapper.find('ModalHeader').text()).toBe('Hello, World');
-    expect(wrapper.find('ModalHeader').children().hasClass('tk-dialog__header')).toBe(true);
-    expect(wrapper.find('ModalBody').text()).toBe('Some text');
-    expect(wrapper.find('ModalBody').children().hasClass('tk-dialog__body')).toBe(true);
-  })
-  it('should render nothing', () => {
-    const wrapper = mount(
-      <Modal size={'small'}>
-        <ModalHeader>Hello, World</ModalHeader>
-        <ModalBody>Some text</ModalBody>
+    const mainCssClass = 'customMainCssClass';
+    const titleCssClass = 'customTitleCssClass';
+    const headerCssClass = 'customHeaderCssClass';
+    const bodyCssClass = 'customBodyCssClass';
+    const footerCssClass = 'customFooterCssClass';
+    const titleText = 'Text in title';
+    const headerText = 'Text in header';
+    const bodyText = 'Text in body';
+    const footerText = 'Text in footer';
+    const { getByText } = render(
+      <Modal size={'small'} className={mainCssClass} show >
+        <ModalTitle className={titleCssClass}>{titleText}</ModalTitle>
+        <ModalHeader className={headerCssClass}>{headerText}</ModalHeader>
+        <ModalBody className={bodyCssClass}>{bodyText}</ModalBody>
+        <ModalFooter className={footerCssClass}>{footerText}</ModalFooter>
       </Modal>
     );
 
-    expect(wrapper.find('Modal').children().length).toBe(0);
-    expect(wrapper.find('ModalHeader').length).toBe(0);
-    expect(wrapper.find('ModalBody').length).toBe(0);
+    const backdrop = document.querySelector('tk-dialog-backdrop');
+    expect(backdrop).toBeDefined();
+
+    // Find Modal
+    const modal = screen.getByRole('dialog');
+    expect(modal).toBeDefined();
+    expect(modal.classList).toContain('tk-dialog');
+    expect(modal.classList).toContain('tk-dialog--small');
+
+    // ModalTitle
+    const title = getByText(titleText);
+    expect(title).toBeDefined();
+    expect(title.classList).toContain(titleCssClass);
+    expect(title.classList).toContain('tk-dialog__title');
+
+    // ModalHeader
+    const header = getByText(headerText);
+    expect(header).toBeDefined();
+    expect(header.classList).toContain(headerCssClass);
+    expect(header.classList).toContain('tk-dialog__header');
+
+    // ModalBody
+    const body = getByText(bodyText);
+    expect(body).toBeDefined();
+    expect(body.classList).toContain(bodyCssClass);
+    expect(body.classList).toContain('tk-dialog__body');
+
+    // ModalFooter
+    const footer = getByText(footerText);
+    expect(footer).toBeDefined();
+    expect(footer.classList).toContain(footerCssClass);
+    expect(footer.classList).toContain('tk-dialog__footer');
+  })
+  it('should render nothing', () => {
+    const titleText = 'Text in title';
+    const headerText = 'Text in header';
+    const bodyText = 'Text in body';
+    const footerText = 'Text in footer';
+    const { queryByText } = render(
+      <Modal size={'small'}>
+        <ModalTitle>{titleText}</ModalTitle>
+        <ModalHeader>{headerText}</ModalHeader>
+        <ModalBody>{bodyText}</ModalBody>
+        <ModalFooter>{footerText}</ModalFooter>
+      </Modal>
+    );
+
+    const modal = screen.queryByRole('dialog');
+    expect(modal).toBeNull();
+
+    expect(queryByText(titleText)).toBeNull();
+    expect(queryByText(headerText)).toBeNull();
+    expect(queryByText(bodyText)).toBeNull();
+    expect(queryByText(footerText)).toBeNull();
   })
   it('should close the Modal on "Esc"', async () => {
     let show = true;

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -14,6 +14,7 @@ type ModalProps = {
 };
 
 type ModalContentProps = {
+  className?: string;
   children?: React.ReactNode;
 };
 
@@ -21,20 +22,24 @@ const prefix = 'tk-dialog';
 const buildClass = (classStr: string) => `${prefix}__${classStr}`;
 
 export const ModalTitle: React.FC<ModalContentProps> = ({
+  className,
   children,
-}: ModalContentProps) => <div className={buildClass('title')}>{children}</div>;
+}: ModalContentProps) => <div className={classNames(buildClass('title'), className)}>{children}</div>;
 
 export const ModalHeader: React.FC<ModalContentProps> = ({
+  className,
   children,
-}: ModalContentProps) => <div className={buildClass('header')}>{children}</div>;
+}: ModalContentProps) => <div className={classNames(buildClass('header'), className)}> {children}</div >;
 
 export const ModalBody: React.FC<ModalContentProps> = ({
+  className,
   children,
-}: ModalContentProps) => <div className={buildClass('body')}>{children}</div>;
+}: ModalContentProps) => <div className={classNames(buildClass('body'), className)}>{children}</div>;
 
 export const ModalFooter: React.FC<ModalContentProps> = ({
+  className,
   children,
-}: ModalContentProps) => <div className={buildClass('footer')}>{children}</div>;
+}: ModalContentProps) => <div className={classNames(buildClass('footer'), className)}> {children}</div >;
 
 const Modal: React.FC<ModalProps> = ({
   size,

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -24,22 +24,26 @@ const buildClass = (classStr: string) => `${prefix}__${classStr}`;
 export const ModalTitle: React.FC<ModalContentProps> = ({
   className,
   children,
-}: ModalContentProps) => <div className={classNames(buildClass('title'), className)}>{children}</div>;
+  ...rest
+}: ModalContentProps) => <div {...rest} className={classNames(buildClass('title'), className)}>{children}</div>;
 
 export const ModalHeader: React.FC<ModalContentProps> = ({
   className,
   children,
-}: ModalContentProps) => <div className={classNames(buildClass('header'), className)}> {children}</div >;
+  ...rest
+}: ModalContentProps) => <div {...rest} className={classNames(buildClass('header'), className)}> {children}</div >;
 
 export const ModalBody: React.FC<ModalContentProps> = ({
   className,
   children,
-}: ModalContentProps) => <div className={classNames(buildClass('body'), className)}>{children}</div>;
+  ...rest
+}: ModalContentProps) => <div {...rest} className={classNames(buildClass('body'), className)}>{children}</div>;
 
 export const ModalFooter: React.FC<ModalContentProps> = ({
   className,
   children,
-}: ModalContentProps) => <div className={classNames(buildClass('footer'), className)}> {children}</div >;
+  ...rest
+}: ModalContentProps) => <div {...rest} className={classNames(buildClass('footer'), className)}> {children}</div >;
 
 const Modal: React.FC<ModalProps> = ({
   size,

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -25,25 +25,25 @@ export const ModalTitle: React.FC<ModalContentProps> = ({
   className,
   children,
   ...rest
-}: ModalContentProps) => <div {...rest} className={classNames(buildClass('title'), className)}>{children}</div>;
+}: ModalContentProps) => <div className={classNames(buildClass('title'), className)} {...rest}>{children}</div>;
 
 export const ModalHeader: React.FC<ModalContentProps> = ({
   className,
   children,
   ...rest
-}: ModalContentProps) => <div {...rest} className={classNames(buildClass('header'), className)}> {children}</div >;
+}: ModalContentProps) => <div className={classNames(buildClass('header'), className)} {...rest}> {children}</div >;
 
 export const ModalBody: React.FC<ModalContentProps> = ({
   className,
   children,
   ...rest
-}: ModalContentProps) => <div {...rest} className={classNames(buildClass('body'), className)}>{children}</div>;
+}: ModalContentProps) => <div className={classNames(buildClass('body'), className)} {...rest}>{children}</div>;
 
 export const ModalFooter: React.FC<ModalContentProps> = ({
   className,
   children,
   ...rest
-}: ModalContentProps) => <div {...rest} className={classNames(buildClass('footer'), className)}> {children}</div >;
+}: ModalContentProps) => <div className={classNames(buildClass('footer'), className)} {...rest}> {children}</div >;
 
 const Modal: React.FC<ModalProps> = ({
   size,

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -47,7 +47,7 @@ const Modal: React.FC<ModalProps> = ({
   ...rest
 }: ModalProps) => {
   const containerClasses = classNames(className, `${prefix}-backdrop`);
-  const sizeClasses = classNames(prefix, `${prefix}--${size}`);
+  const sizeClasses = classNames(prefix, { [`${prefix}--${size}`]: size });
   const handleContentClick = (event: React.MouseEvent<HTMLElement>) =>
     event.stopPropagation();
   const handleKeyUp = (event: React.KeyboardEvent<HTMLElement>) => {

--- a/stories/Modal.stories.tsx
+++ b/stories/Modal.stories.tsx
@@ -50,10 +50,10 @@ const body = (
 );
 
 const footer = (
-  <div>
+  <>
     <Button variant={'tertiary'}>Cancel</Button>
     <Button variant={'primary'}>Confirm</Button>
-  </div>
+  </>
 );
 
 export const SmallModal: React.FC = () => {

--- a/stories/Modal.stories.tsx
+++ b/stories/Modal.stories.tsx
@@ -97,6 +97,17 @@ export const FullPageModal: React.FC = () => {
   );
 };
 
+export const CustomCssClassModal: React.FC = () => {
+  return (
+    <Modal size={'medium'} className={'myModalClass'} closeButton show>
+      <ModalTitle className={'myModalTitleClass'}>Modal with additional custom CSS classes</ModalTitle>
+      <ModalHeader className={'myModalHeaderClass'}>{body}</ModalHeader>
+      <ModalBody className={'myModalBodyClass'}>{body}</ModalBody>
+      <ModalFooter className={'myModalFooterClass'}>{footer}</ModalFooter>
+    </Modal>
+  );
+};
+
 export const ModalWithCloseHandler: React.FC = () => {
   const [show, setShow] = React.useState(true);
   const handleClose = () => { setShow(false) }


### PR DESCRIPTION
**Jira ticket**
https://perzoinc.atlassian.net/browse/APP-4195

**Changes**
- Remove enzyme from Modal tests to use only testing-library
- Add tests for: ModalTitle, ModalHeader, ModalBody, ModalFooter
- Allow sending additional parameters (class, aria, etc...) to the ModalTitle, ModalHeader, ModalBody, ModalFooter
- Fix: 'undefined' class when no size was given in the attribute

**Test coverage of the Modal**
![Screenshot 2021-06-24 at 12 21 57](https://user-images.githubusercontent.com/66668470/123247138-d79eb080-d4e6-11eb-90a2-367bfff75e48.png)


(Related PR: https://github.com/SymphonyPlatformSolutions/symphony-bdk-ui-toolkit-styles/pull/106)