### PR TITLE
EIS-3348: Add Banner component

### DIFF
--- a/spec/components/banner/Banner.spec.tsx
+++ b/spec/components/banner/Banner.spec.tsx
@@ -1,0 +1,141 @@
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import { Banner, BannerType } from '../../../src/components';
+
+describe('Banner', () => {
+
+  const actionMock = jest.fn();
+  const closeMock = jest.fn();
+
+  const infoValue = BannerType.INFO;
+
+  it('should render a default banner (neutral, no action, no close)', () => {
+
+    const props = {
+      'data-testid': 'banner',
+      content: 'aContent',
+    }
+
+    const helper = render(<Banner {...props} />);
+
+    expect(helper.getByTestId(props['data-testid'])).toHaveClass(`tk-banner--${infoValue}`);
+    expect(helper.getByTestId(props['data-testid'])).toHaveClass('tk-banner--medium');
+    expect(helper.getByText(props.content)).toBeInTheDocument();
+    expect(helper.container.querySelector('[class*="tk-banner__action"]')).not.toBeInTheDocument();
+    expect(helper.container.querySelector('[class*="tk-banner__close"]')).not.toBeInTheDocument();
+
+  });
+
+  it('should not render if show is false', () => {
+
+    const props = {
+      'data-testid': 'banner',
+      content: 'aContent',
+      show: false,
+    }
+
+    const helper = render(<Banner {...props} />);
+
+    expect(helper.queryByTestId(props['data-testid'])).not.toBeInTheDocument();
+    expect(helper.queryByText(props.content)).not.toBeInTheDocument();
+
+  });
+
+  it('should render the action button if provided', () => {
+
+    const props = {
+      'data-testid': 'banner',
+      content: 'aContent',
+      actionText: 'anAction',
+      onAction: actionMock,
+    }
+
+    const helper = render(<Banner {...props} />);
+
+    expect(helper.getByText(props.actionText)).toBeInTheDocument();
+
+  });
+
+  it('should call the action handler on action clicked', async () => {
+
+    const props = {
+      'data-testid': 'banner',
+      content: 'aContent',
+      actionText: 'anAction',
+      onAction: actionMock,
+    }
+
+    const helper = render(<Banner {...props} />);
+
+    userEvent.click(helper.getByText(props.actionText));
+
+    await waitFor(() => {
+      expect(actionMock).toHaveBeenCalledTimes(1);
+    });
+
+  });
+
+  it('should render the close button if isClosable', () => {
+
+    const props = {
+      'data-testid': 'banner',
+      content: 'aContent',
+      isClosable: true,
+      onClose: closeMock,
+    }
+
+    const helper = render(<Banner {...props} />);
+
+    expect(helper.container.querySelector('[class*="tk-banner__close"]')).toBeInTheDocument();
+
+  });
+
+  it('should call the close handler on close clicked', async () => {
+
+    const props = {
+      'data-testid': 'banner',
+      content: 'aContent',
+      isClosable: true,
+      onClose: closeMock,
+    }
+
+    const helper = render(<Banner {...props} />);
+
+    userEvent.click(helper.container.querySelector('[class*="tk-banner__close"]'));
+
+    await waitFor(() => {
+      expect(closeMock).toHaveBeenCalledTimes(1);
+    });
+
+  });
+
+  it('should apply a classname if provided', () => {
+
+    const props = {
+      'data-testid': 'banner',
+      content: 'aContent',
+      className: 'aClassName'
+    }
+
+    const helper = render(<Banner {...props} />);
+
+    expect(helper.getByTestId(props['data-testid'])).toHaveClass(props.className);
+  });
+
+  it.each(Object.values(BannerType))(
+    'should render the variant "%s"',
+    (variant: BannerType) => {
+
+      const props = {
+        'data-testid': 'banner',
+        content: 'aContent',
+        variant,
+      }
+
+      const helper = render(<Banner {...props} />);
+
+      expect(helper.getByTestId(props['data-testid'])).toHaveClass(`tk-banner--${variant}`);
+    }
+  )
+});

--- a/src/components/banner/Banner.tsx
+++ b/src/components/banner/Banner.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { BannerType, BannerProps } from './interfaces';
+
+export const Banner: React.FC<BannerProps> = ({
+  className,
+  isClosable,
+  onClose,
+  actionText,
+  onAction,
+  content,
+  show,
+  variant,
+  size,
+  ...otherProps
+}) => {
+
+  if (!show) {
+    return null
+  }
+
+  return (
+    <div className={classNames(
+      'tk-banner',
+      `tk-banner--${variant}`,
+      `tk-banner--${size}`,
+      { [className]: !!className },
+    )}
+    {...otherProps}
+    >
+      {/* Variant icon */}
+      <div className="tk-banner__variant-icon" />
+
+      {/* Content */}
+      <div className="tk-banner__content">{content}</div>
+
+      {/* Action (optional) */}
+      {actionText && onAction && (
+        <button type="button" onClick={onAction} className="tk-banner__action">
+          {actionText}
+        </button>
+      )}
+
+      {/* Close button (optional) */}
+      {isClosable && onClose && (
+        <div className="tk-banner__close" onClick={onClose} />
+      )}
+
+    </div>
+  )
+}
+
+Banner.defaultProps = {
+  variant: BannerType.INFO,
+  size: 'medium',
+  show: true,
+}
+
+Banner.propTypes = {
+  className: PropTypes.string,
+  isClosable: PropTypes.bool,
+  content: PropTypes.string.isRequired,
+  onClose: PropTypes.func,
+  show: PropTypes.bool,
+  variant: PropTypes.oneOf(Object.values(BannerType)),
+  size: PropTypes.oneOf(['small', 'medium']),
+  actionText: PropTypes.string,
+  onAction: PropTypes.func,
+};

--- a/src/components/banner/index.ts
+++ b/src/components/banner/index.ts
@@ -1,0 +1,5 @@
+import { Banner } from './Banner';
+import { BannerType } from './interfaces';
+
+export { Banner, BannerType };
+

--- a/src/components/banner/interfaces.ts
+++ b/src/components/banner/interfaces.ts
@@ -1,0 +1,30 @@
+export type BannerProps = {
+  /** Optional CSS class name */
+  className?: string;
+  /** If true, close icon will be placed to the right */
+  isClosable?: boolean;
+  /** Function to call on close action */
+  onClose?: () => void;
+  /** Content of the Banner */
+  content: string;
+  /** If Banner should be shown or not */
+  show?: boolean;
+  /** Style of the banner */
+  variant?: BannerType;
+  /** Text of the action button */
+  actionText?: string;
+  /** Function to call on action click */
+  onAction?: () => void;
+  /** Size of the banner */
+  size?: 'small' | 'medium';
+
+  /** other props */
+  [otherProps: string]: any,
+}
+
+export enum BannerType {
+  INFO = 'info',
+  SUCCESS = 'success',
+  WARNING = 'warning',
+  ERROR = 'error',
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -26,6 +26,7 @@ import VirtualizedList from './virtualized-list';
 
 /* Let's move into exporting everything with interfaces */
 export * from './avatar';
+export * from './banner';
 export * from './button';
 export * from './dropdown';
 export * from './nav';

--- a/stories/Banner.stories.tsx
+++ b/stories/Banner.stories.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { Banner, BannerType } from '../src/components';
+
+export default {
+  title: 'Components/Banner',
+  component: Banner,
+  decorators: [
+    (Story) => (
+      <div style={{ margin: '0 auto', textAlign: 'center' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    variant: {
+      control: {
+        type: 'select',
+        options: Object.values(BannerType),
+      },
+    },
+    size: {
+      control: {
+        type: 'select',
+        options: ['small', 'medium'],
+      },
+    },
+  }
+};
+
+const Template = (args) => {
+  const { onClose, ...restProps } = args;
+
+  const [showBanner, setShowBanner] = useState(true);
+
+  const handleClickClose = () => {
+    setShowBanner(false);
+    onClose();
+  };
+
+  return <Banner
+    onClose={handleClickClose}
+    show={showBanner}
+    content="Banner text content here"
+    {...restProps}
+  />;
+};
+
+
+const commonProps = {
+  actionText: 'Action',
+  onAction: () => { alert('action clicked') },
+  isClosable: true,
+  onClose: () => { alert('close clicked') },
+}
+
+export const Default = Template.bind({});
+Default.args = {
+  ...commonProps,
+  content: 'Banner text content here',
+};
+
+export const WithActionOnly = Template.bind({});
+WithActionOnly.args = {
+  actionText: 'Action',
+  onAction: () => { alert('action clicked') },
+};
+
+export const WithCloseOnly = Template.bind({});
+WithCloseOnly.args = {
+  isClosable: true,
+  onClose: () => { alert('close clicked') },
+};
+
+export const MultilineContent = Template.bind({});
+MultilineContent.args = {
+  ...commonProps,
+  content: 'This is a very long banner content that should be displayed on multiple lines. This is a very long banner content that should be displayed on multiple lines.'
+};
+
+export const SuccessVariant = Template.bind({});
+SuccessVariant.args = {
+  ...commonProps,
+  variant: BannerType.SUCCESS,
+};
+
+export const WarningVariant = Template.bind({});
+WarningVariant.args = {
+  ...commonProps,
+  variant: BannerType.WARNING,
+};
+
+export const ErrorVariant = Template.bind({});
+ErrorVariant.args = {
+  ...commonProps,
+  variant: BannerType.ERROR,
+};
+
+export const SmallSize = Template.bind({});
+SmallSize.args = {
+  ...commonProps,
+  size: 'small',
+};


### PR DESCRIPTION
**EIS-3348: Add Banner component**

- add Banner.ts and BannerUtils.ts
- add related unit tests
- add related stories
- export Banner component

Ticket: [https://perzoinc.atlassian.net/browse/EIS-3348](https://perzoinc.atlassian.net/browse/EIS-3348)
Figma: [https://www.figma.com/file/V0VKw74594EyCKHwqYk6LV/%E2%9D%96-SDS-Core-Component-Library?node-id=5272%3A9287](https://www.figma.com/file/V0VKw74594EyCKHwqYk6LV/%E2%9D%96-SDS-Core-Component-Library?node-id=5272%3A9287)
Related PR (styles): [https://github.com/SymphonyPlatformSolutions/symphony-bdk-ui-toolkit-styles/pull/107](https://github.com/SymphonyPlatformSolutions/symphony-bdk-ui-toolkit-styles/pull/107)

--------

**EDIT**

- `onClickAction` has been renamed to `onAction`
- `onClickClose` has been renamed to `onClose`
- `canClose` has been renamed to `isClosable`
- `BannerUtils` has been renamed to `interfaces.ts`
- variant icons are now handled in CSS directly, based on the variant class
- `BannerIcon` enum has been removed
- variant and size class names are using `--` instead of `__` (ex: `tk-banner__info` --> `tk-banner--info`)
- variants `NEUTRAL`, `POSITIVE`, `ATTENTION` and `NEGATIVE` have been renamed to `INFO`, `SUCCESS`, `WARNING` and `ERROR`

--------

**Info (default)**

![Screenshot 2021-06-25 at 18 03 14](https://user-images.githubusercontent.com/66251236/123457333-1d8d6e80-d5e4-11eb-8b60-37f366759e97.png)

**Success**

![Screenshot 2021-06-25 at 18 03 25](https://user-images.githubusercontent.com/66251236/123457337-1e260500-d5e4-11eb-83d7-c399b74efbfa.png)

**Warning**

![Screenshot 2021-06-25 at 18 03 44](https://user-images.githubusercontent.com/66251236/123457338-1ebe9b80-d5e4-11eb-9ff4-6e3bdaf293f8.png)

**Error**

![Screenshot 2021-06-25 at 18 03 53](https://user-images.githubusercontent.com/66251236/123457341-1ebe9b80-d5e4-11eb-9f5c-c8a0dba0488d.png)

**No action**

![Screenshot 2021-06-25 at 18 04 06](https://user-images.githubusercontent.com/66251236/123457342-1ebe9b80-d5e4-11eb-82f6-c8e3ef87b746.png)

**No action and no close**

![Screenshot 2021-06-25 at 18 04 16](https://user-images.githubusercontent.com/66251236/123457344-1f573200-d5e4-11eb-9b50-9ec96a6922b8.png)

**Content overflow**

![Screenshot 2021-06-25 at 18 09 32](https://user-images.githubusercontent.com/66251236/123457345-1f573200-d5e4-11eb-95f9-cc909bf100e8.png)

**Small size**

<img width="447" alt="Screenshot 2021-06-25 at 18 36 14" src="https://user-images.githubusercontent.com/66251236/123457474-3eee5a80-d5e4-11eb-98fa-2c1e79244cc1.png">

----------

**Dark theme**

<img width="447" alt="Screenshot 2021-06-25 at 18 36 57" src="https://user-images.githubusercontent.com/66251236/123457645-6a714500-d5e4-11eb-8698-3738c7b6e45d.png">
<img width="441" alt="Screenshot 2021-06-25 at 18 37 08" src="https://user-images.githubusercontent.com/66251236/123457647-6b09db80-d5e4-11eb-8a85-9551f0b61fa8.png">
<img width="445" alt="Screenshot 2021-06-25 at 18 37 16" src="https://user-images.githubusercontent.com/66251236/123457650-6b09db80-d5e4-11eb-9803-b4f87f1c1728.png">
<img width="446" alt="Screenshot 2021-06-25 at 18 37 23" src="https://user-images.githubusercontent.com/66251236/123457652-6ba27200-d5e4-11eb-8c67-8c8504ddc50d.png">
