### PR TITLE
RTC-10806 - Improvements to the Dropdown component

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@types/lodash": "^4.14.154",
     "@types/react": "^16.9.35",
     "@types/react-dom": "^16.9.8",
-    "@types/react-select": "^4.0.11",
+    "@types/react-select": "^4.0.17",
     "@types/react-virtualized": "^9.21.10",
     "@types/storybook__react": "^5.2.1",
     "@types/styled-components": "5.1.0",

--- a/spec/components/dropdown/Dropdown.spec.tsx
+++ b/spec/components/dropdown/Dropdown.spec.tsx
@@ -288,7 +288,7 @@ describe('Dropdown component test suite =>', () => {
         })
       });
       it('should filter the `asyncOptions` if user types on the input', async () => {
-        const { getByText, queryByText } = render(<Dropdown asyncOptions={() => Promise.resolve(options)} />);
+        const { queryByText } = render(<Dropdown asyncOptions={() => Promise.resolve(options)} />);
         const input =  screen.getByRole('textbox');
         userEvent.click(input);
         await waitFor(async () => {

--- a/src/components/dropdown/CustomRender.tsx
+++ b/src/components/dropdown/CustomRender.tsx
@@ -188,7 +188,12 @@ export const DropdownList = ({selectProps, ...props}: any) => {
       }
     }, [select?.state?.focusedOption]);
   }
-  return <components.MenuList {...props}>{props.children}</components.MenuList>;
+  return <components.MenuList
+    className={ 'tk-mt-1 tk-mb-1' }
+    {...props}
+  >
+    {props.children}
+  </components.MenuList>;
 };
 
 export const firstOption: Readonly<SearchHeaderOption> = {

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -75,7 +75,9 @@ export type DropdownProps<T> = {
   menuIsOpen?: boolean;
   /** Placement of the menu in relation to the control */
   menuPlacement?: MenuPlacement;
-  /** Styling options depending on the need  */
+  /** Whether the Dropdown menu should scroll into view when pressed */
+  menuShouldScrollIntoView?: boolean;
+  /** Styling options depending on the need */
   mode?: 'nested' | 'aligned';
   name?: string;
   /** Mesage to display if there isn't any match in the search input */
@@ -114,8 +116,10 @@ export type DropdownProps<T> = {
     | React.FunctionComponent<TagRendererProps<T>>;
   /** Message to be display on the header of the menu list when searching by term */
   termSearchMessage?: ((term: string) => string) | string;
-} & HasTooltipProps &
-  (MultiModeProps<T> | SingleModeProps<T>) & (AsyncProps<T> | SyncProps<T>);
+} &
+  HasTooltipProps &
+  (MultiModeProps<T> | SingleModeProps<T>) &
+  (AsyncProps<T> | SyncProps<T>);
 
 type MultiModeProps<T> = {
   /** Support multiple selected options */
@@ -154,7 +158,7 @@ type DropdownState<T> = {
   closeMenuOnSelect?: boolean;
   hideSelectedOptions?: boolean;
   displayArrowIndicator?: boolean;
-  DropdownTag: any;
+  DropdownTag: Select | any;
 };
 export class Dropdown<T = LabelValue> extends React.Component<
   DropdownProps<T>,
@@ -168,7 +172,7 @@ export class Dropdown<T = LabelValue> extends React.Component<
     this.myRef = React.createRef();
     this.searchHeaderOption = { ...firstOption };
     this.state = {
-      DropdownTag:  this.props.options ? Select : AsyncSelect,
+      DropdownTag: this.props.options ? Select : AsyncSelect,
       selectedOption: null,
       hideSelectedOptions:
         this.props.hideSelectedOptions === undefined
@@ -299,7 +303,9 @@ export class Dropdown<T = LabelValue> extends React.Component<
       termSearchMessage,
       value,
       defaultOptions,
-      menuPlacement
+      menuPlacement,
+      menuShouldScrollIntoView,
+      ...otherProps
     } = this.props;
 
     return (
@@ -312,7 +318,8 @@ export class Dropdown<T = LabelValue> extends React.Component<
           tooltipCloseLabel={tooltipCloseLabel}
           showRequired={showRequired}
         />
-        <DropdownTag 
+        <DropdownTag
+          {...otherProps}
           styles={{
             valueContainer: provided => ({
               ...provided,  maxHeight:`${maxHeight}px`})
@@ -379,6 +386,7 @@ export class Dropdown<T = LabelValue> extends React.Component<
           termSearchMessage={termSearchMessage}
           getOptionValue={this.bindValue}
           blurInputOnSelect={blurInputOnSelect}
+          menuShouldScrollIntoView={menuShouldScrollIntoView}
         />
       </div>
     );
@@ -391,6 +399,7 @@ export class Dropdown<T = LabelValue> extends React.Component<
     isTypeAheadEnabled: true,
     autoScrollToCurrent: false,
     enableTermSearch: false,
+    menuShouldScrollIntoView: true,
     menuPlacement: 'auto'
   };
 }

--- a/stories/Dropdown.stories.tsx
+++ b/stories/Dropdown.stories.tsx
@@ -214,6 +214,7 @@ export const Select: React.FC = () => (
       tagRenderer={IconPickerRenderer}
       onTermSearch={onTermSearch}
     />
+
     <p className="tk-mt-4">With <strong> tagRenderer </strong>prop you can customize the rendering of the selected item/s: </p>
     <Dropdown
       options={iconData}
@@ -223,9 +224,9 @@ export const Select: React.FC = () => (
       placeHolder="Select an icon.."
       filterFunction={filterFunction}
     />
+
     <h2 className="tk-mt-5h">Custom Filter logic</h2>
     <p>If you would like to rewrite the filtration logic from the ground up, simply declare a new <strong> filterFunction </strong> to be passed in as a prop:</p>
-    
     <Dropdown
       options={iconData}
       tagRenderer={IconPickerTagRenderer}
@@ -233,7 +234,13 @@ export const Select: React.FC = () => (
       isMultiSelect
       placeHolder="Select an icon.."
       filterFunction={filterFunction}
-  
+    />
+
+    <h2 className="tk-mt-5h">Scroll into view - disabled</h2>
+    <p>{"When pressing the dropdown while it's not fully in view, it will not scroll into view"}</p>
+    <Dropdown
+      options={defaultOptions}
+      menuShouldScrollIntoView={false}
     />
   </div>
 );

--- a/stories/stories.scss
+++ b/stories/stories.scss
@@ -1,5 +1,5 @@
 html {
-  font-family: 'SymphonyLato', 'Lato', 'Segoe UI', 'Helvetica Neue', 'Verdana',
+  font-family: 'system-ui', 'Lato', 'Segoe UI', 'Helvetica Neue', 'Verdana',
     'Arial', sans-serif;
   font-size: 16px;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2662,10 +2662,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-select@^4.0.11":
-  version "4.0.15"
-  resolved "https://registry.yarnpkg.com/@types/react-select/-/react-select-4.0.15.tgz#2e6a1cff22c4bbae6c95b8dbee5b5097c12eae54"
-  integrity sha512-GPyBFYGMVFCtF4eg9riodEco+s2mflR10Nd5csx69+bcdvX6Uo9H/jgrIqovBU9yxBppB9DS66OwD6xxgVqOYQ==
+"@types/react-select@^4.0.17":
+  version "4.0.17"
+  resolved "https://registry.yarnpkg.com/@types/react-select/-/react-select-4.0.17.tgz#2e5ab4042c09c988bfc2711550329b0c3c9f8513"
+  integrity sha512-ZK5wcBhJaqC8ntQl0CJvK2KXNNsk1k5flM7jO+vNPPlceRzdJQazA6zTtQUyNr6exp5yrAiwiudtYxgGlgGHLg==
   dependencies:
     "@emotion/serialize" "^1.0.0"
     "@types/react" "*"


### PR DESCRIPTION
https://perzoinc.atlassian.net/browse/RTC-10806

- Added menuShouldScrollIntoView argument from react-select.

See SDS (Symphony Design System) for latest designs on the Select component - https://www.figma.com/file/V0VKw74594EyCKHwqYk6LV/%E2%9D%96-SDS-Core-Component-Library?node-id=5453%3A17120

https://github.com/SymphonyPlatformSolutions/symphony-bdk-ui-toolkit-styles/pull/115 - has to merge first.

Tested with MacOS VoiceOver and aria-label works on the component.