### PR TITLE
EIS-3533 - add classname prop to InputDecorator

### DIFF
--- a/src/components/input/InputDecorator.tsx
+++ b/src/components/input/InputDecorator.tsx
@@ -25,6 +25,7 @@ const InputDecoratorPropTypes = {
 
 type InputDecoratorProps = {
   rightDecorators?: JSX.Element | JSX.Element[];
+  className?: string,
   children: React.ReactElement;
 } & LabelTooltipDecoratorProps &
   HasValidationProps<string>;
@@ -35,6 +36,7 @@ const InputDecorator: React.FC<InputDecoratorProps> = ({
   tooltip,
   tooltipCloseLabel,
   showRequired,
+  className,
   children,
   onInit,
   onValidationChanged,
@@ -85,7 +87,7 @@ const InputDecorator: React.FC<InputDecoratorProps> = ({
 
   return (
     <div
-      className={classnames('tk-input-group', {
+      className={classnames('tk-input-group', className, {
         'tk-input-group--disabled': disabled,
       })}
     >


### PR DESCRIPTION
to handle layout we need the prop classname to be added to the InputDecorator Component

![Screenshot 2021-07-19 at 15 17 42](https://user-images.githubusercontent.com/54842163/126166610-fde3810b-7e58-4968-b655-1a69f21a098e.png)
![Screenshot 2021-07-19 at 14 52 34](https://user-images.githubusercontent.com/54842163/126166616-76cf9078-5dd4-4853-8956-2e5859c2487c.png)
