### PR TITLE
fix: memoize tooltip debouncer

### DIFF
--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import * as PropTypes from 'prop-types';
 import { usePopper } from 'react-popper';
 import { CSSTransition } from 'react-transition-group';
@@ -112,7 +112,7 @@ const Tooltip: React.FC<TooltipProps> = ({
   const [showHover, setShowHover] = useState(false);
   const [showClick, setShowClick] = useState(false);
 
-  const handleMouseMove = debouncer(setShowHover, hoverDelay, hoverTimeout);
+  const handleMouseMove = useMemo(() => debouncer(setShowHover, hoverDelay, hoverTimeout), [hoverDelay, hoverTimeout]);
 
   const ref = useOnclickOutside(
     () => {


### PR DESCRIPTION
Without the memoization of the debouncer we have side effect due to rerender that loose the timeout inside the deboucer function (need it to clearTimeout).

Without memo:

https://user-images.githubusercontent.com/68021464/126173419-52cd0c6e-aa2f-4021-92ac-f3af60245738.mp4

With memo:

https://user-images.githubusercontent.com/68021464/126173462-3a8383c6-b3aa-4782-af47-9aca1b3c1d34.mp4


