### PR TITLE
APP-4317 Fix not supported property on Checkbox and fix lint warnings

### DIFF
--- a/spec/components/dropdown/Dropdown.spec.tsx
+++ b/spec/components/dropdown/Dropdown.spec.tsx
@@ -8,22 +8,22 @@ import { Validators } from '../../../src/core/validators/validators';
 import { Keys } from '../../../src/components/common/keyUtils';
 
 const CustomComponent = (props) => {
-  if (props.data){
+  if (props.data) {
     return (<div>{props?.data?.label}</div>);
   }
 }
 const filterFunction = (element: any, input: string) => {
-  return !input || element.displayName.indexOf(input)>-1 ;
+  return !input || element.displayName.indexOf(input) > -1;
 };
 
-const onChange =jest.fn();
-const onTermSearch =jest.fn();
-const onClear =jest.fn();
-const onBlur =jest.fn();
-const optionDisabled =jest.fn();
-const optionSelected =jest.fn();
+const onChange = jest.fn();
+const onTermSearch = jest.fn();
+const onClear = jest.fn();
+const onBlur = jest.fn();
+const optionDisabled = jest.fn();
+const optionSelected = jest.fn();
 
-const options = [ { label: 'banana' }, { label: 'avocado' }, { label: 'orange' } ]
+const options = [{ label: 'banana' }, { label: 'avocado' }, { label: 'orange' }]
 
 describe('Dropdown component test suite =>', () => {
   const dropdownProps = {
@@ -35,14 +35,14 @@ describe('Dropdown component test suite =>', () => {
     beforeEach(() => {
       dropdownProps.options = options;
     });
-  
+
     describe('when is simple Dropdown', () => {
       it('should render the Dropdown component by default', async () => {
         const { getByText } = render(<Dropdown options={dropdownProps.options} />);
         expect(getByText('Select...')).toBeInTheDocument();
-      
+
       });
-  
+
       it('should render the Dropdown component by default', async () => {
         const timeZoneOptions: DropdownOption<LabelValue>[] = [
           { label: '(GMT +03:00) Tanzania', value: '8' },
@@ -57,25 +57,25 @@ describe('Dropdown component test suite =>', () => {
             ]
           }
         ];
-        render(<Dropdown options={timeZoneOptions} mode="nested"/>);
+        render(<Dropdown options={timeZoneOptions} mode="nested" />);
         const input = screen.getByRole('textbox');
         userEvent.click(input);
         const nestedItem = screen.getByText('(GMT -04:00) United states of America (USA) - New York');
         expect(nestedItem.classList.contains('tk-select__option--nested')).toBeTruthy();
       });
-    
+
       it('should show/hide options menu', async () => {
-        const { getByText } = render(<Dropdown options={dropdownProps.options} hideSelectedOptions closeMenuOnSelect enableTermSearch/>);
+        const { getByText } = render(<Dropdown options={dropdownProps.options} hideSelectedOptions closeMenuOnSelect enableTermSearch />);
         const input = screen.getByRole('textbox');
         userEvent.click(input);
         expect(getByText('banana')).toBeTruthy();
         expect(getByText('avocado')).toBeTruthy();
         expect(getByText('orange')).toBeTruthy();
-  
+
       });
-    
+
       it('should select first option', async () => {
-        const { getByText } = render(<Dropdown options={dropdownProps.options} noOptionMessage="no options message"/>);
+        const { getByText } = render(<Dropdown options={dropdownProps.options} noOptionMessage="no options message" />);
         const input = screen.getByRole('textbox');
         userEvent.click(input);
         const option = screen.getByText('banana');
@@ -84,7 +84,7 @@ describe('Dropdown component test suite =>', () => {
         userEvent.type(input, 'zz');
         expect(screen.getByText('no options message')).toBeTruthy();
       });
-    
+
       it('should render costum render dropdown', async () => {
         const { container, getByText } = render(
           <Dropdown
@@ -109,23 +109,23 @@ describe('Dropdown component test suite =>', () => {
         expect(getByText('Select...')).toBeTruthy();
       });
     });
-  
+
     describe('when is Multiselect', () => {
-  
+
       it('should render the Multiselect component by default', async () => {
         const { getByText } = render(<Dropdown options={dropdownProps.options} isMultiSelect />);
         expect(getByText('Select...')).toBeInTheDocument();
       });
-    
+
       it('should show/hide options menu', async () => {
-        const { getByText } = render(<Dropdown options={dropdownProps.options} isMultiSelect filterFunction={filterFunction}/>);
+        const { getByText } = render(<Dropdown options={dropdownProps.options} isMultiSelect filterFunction={filterFunction} />);
         const input = screen.getByRole('textbox');
         userEvent.click(input);
         expect(getByText('banana')).toBeTruthy();
         expect(getByText('avocado')).toBeTruthy();
         expect(getByText('orange')).toBeTruthy();
       });
-    
+
       it('should select first option', async () => {
         const { getByText } = render(<Dropdown options={dropdownProps.options} isMultiSelect />);
         const input = screen.getByRole('textbox');
@@ -134,9 +134,9 @@ describe('Dropdown component test suite =>', () => {
         userEvent.click(option);
         expect(getByText('banana')).toBeTruthy();
       });
-  
+
       it('should clean selection', () => {
-        const { getByText, container} = render(<Dropdown options={dropdownProps.options} isMultiSelect />);
+        const { getByText, container } = render(<Dropdown options={dropdownProps.options} isMultiSelect />);
         const input = screen.getByRole('textbox');
         userEvent.click(input);
         const option = screen.getByText('banana');
@@ -145,7 +145,7 @@ describe('Dropdown component test suite =>', () => {
         userEvent.click(cross);
         expect(getByText('Select...')).toBeTruthy();
       });
-    
+
       it('should render custom render dropdown', async () => {
         const { getByText } = render(
           <Dropdown
@@ -163,7 +163,7 @@ describe('Dropdown component test suite =>', () => {
         expect(getByText('banana')).toBeTruthy();
       });
     });
-  
+
     describe('when search by term is enabled', () => {
       it('should render the header option when user starts typing', async () => {
         const { queryByText } = render(
@@ -175,13 +175,13 @@ describe('Dropdown component test suite =>', () => {
           />
         );
         const input = screen.getByRole('textbox');
-        userEvent.type(input,'B');
+        userEvent.type(input, 'B');
         expect(queryByText(/Search for term/)).toBeInTheDocument();
       });
-   
+
       describe('when focusing on the dropdown list', () => {
         it('should focus on the first option (skiping the headerOption) when there is a value on the input', async () => {
-          const {  getByText } = render(
+          const { getByText } = render(
             <Dropdown
               options={dropdownProps.options}
               displayArrowIndicator
@@ -189,12 +189,12 @@ describe('Dropdown component test suite =>', () => {
             />
           );
           const input = screen.getByRole('textbox');
-          userEvent.type(input,'B');
+          userEvent.type(input, 'B');
           expect(getByText('banana').className).toContain('tk-select__option--is-focused');
         });
-  
+
         it('should focus on the first option (skiping the headerOption) when the user presses the `home` key', async () => {
-          const {  getByText } = render(
+          const { getByText } = render(
             <Dropdown
               options={dropdownProps.options}
               displayArrowIndicator
@@ -209,10 +209,10 @@ describe('Dropdown component test suite =>', () => {
           expect(getByText('banana').className).toContain('tk-select__option--is-focused');
         });
       });
-    
+
       it('should select option header', async () => {
-        const searchedTerm ='BBBmous';
-        const {  getByText, queryByText } = render(
+        const searchedTerm = 'BBBmous';
+        const { getByText, queryByText } = render(
           <Dropdown
             isOptionDisabled={optionDisabled}
             isOptionSelected={optionSelected}
@@ -227,14 +227,14 @@ describe('Dropdown component test suite =>', () => {
         const input = screen.getByRole('textbox');
         fireEvent.blur(input);
         expect(onBlur).toBeCalled();
-        userEvent.type(input,searchedTerm);
+        userEvent.type(input, searchedTerm);
         fireEvent.mouseDown(input);
         //Select header option
         fireEvent.click(queryByText(/Search for term/));
         expect(getByText(searchedTerm)).toBeInTheDocument();
       });
     });
-  
+
     describe('when is with Validation Component', () => {
       it('should be triggered on Blur and on Change', async () => {
         const { getByText } = render(<>
@@ -258,7 +258,7 @@ describe('Dropdown component test suite =>', () => {
         const button = screen.getByRole('button');
         userEvent.click(button);
         await waitFor(() => expect(getByText('This field is required')).toBeTruthy())
-  
+
         // on Change
         userEvent.click(input);
         const option = screen.getByText('banana');
@@ -268,7 +268,7 @@ describe('Dropdown component test suite =>', () => {
       });
     });
   });
-  
+
 
   describe('when options are Async', () => {
 
@@ -278,78 +278,78 @@ describe('Dropdown component test suite =>', () => {
         expect(getByText('Select...')).toBeInTheDocument();
       });
       it('should render the `asyncOptions` to the dropdown menu', async () => {
-        const { getByText } = render(<Dropdown asyncOptions={() => Promise.resolve(options)} defaultOptions/>);
-        const input =  screen.getByRole('textbox');
+        const { getByText } = render(<Dropdown asyncOptions={() => Promise.resolve(options)} defaultOptions />);
+        const input = screen.getByRole('textbox');
         userEvent.click(input);
         await waitFor(async () => {
-          expect( getByText('banana')).toBeTruthy();
-          expect( getByText('avocado')).toBeTruthy();
-          expect( getByText('orange')).toBeTruthy();
+          expect(getByText('banana')).toBeTruthy();
+          expect(getByText('avocado')).toBeTruthy();
+          expect(getByText('orange')).toBeTruthy();
         })
       });
       it('should filter the `asyncOptions` if user types on the input', async () => {
         const { queryByText } = render(<Dropdown asyncOptions={() => Promise.resolve(options)} />);
-        const input =  screen.getByRole('textbox');
+        const input = screen.getByRole('textbox');
         userEvent.click(input);
         await waitFor(async () => {
-          expect( queryByText('banana')).toBeTruthy();
-          expect( queryByText('avocado')).toBeTruthy();
-          expect( queryByText('orange')).toBeTruthy();
+          expect(queryByText('banana')).toBeTruthy();
+          expect(queryByText('avocado')).toBeTruthy();
+          expect(queryByText('orange')).toBeTruthy();
         })
         userEvent.type(input, 'ban');
         await waitFor(async () => {
-          expect( queryByText('banana')).toBeTruthy();
-          expect( queryByText('avocado')).toBeFalsy();
-          expect( queryByText('orange')).toBeFalsy();
+          expect(queryByText('banana')).toBeTruthy();
+          expect(queryByText('avocado')).toBeFalsy();
+          expect(queryByText('orange')).toBeFalsy();
         })
       });
       describe('when `defaultOptions` is provided with a different list', () => {
         it('should render different default options to the dropdown menu', async () => {
-          const { getByText } = render(<Dropdown asyncOptions={() => Promise.resolve(options)} defaultOptions={[{label:'salmon'}]} />);
-          const input =  screen.getByRole('textbox');
+          const { getByText } = render(<Dropdown asyncOptions={() => Promise.resolve(options)} defaultOptions={[{ label: 'salmon' }]} />);
+          const input = screen.getByRole('textbox');
           userEvent.click(input);
-          expect( getByText('salmon')).toBeTruthy();
+          expect(getByText('salmon')).toBeTruthy();
         });
         it('should filter the options if user types on the input', async () => {
-          const { getByText,queryByText } = render(<Dropdown asyncOptions={() => Promise.resolve(options)} defaultOptions={[{label:'salmon'}]} />);
-          const input =  screen.getByRole('textbox');
+          const { getByText, queryByText } = render(<Dropdown asyncOptions={() => Promise.resolve(options)} defaultOptions={[{ label: 'salmon' }]} />);
+          const input = screen.getByRole('textbox');
           userEvent.click(input);
-          expect( getByText('salmon')).toBeTruthy();
+          expect(getByText('salmon')).toBeTruthy();
           userEvent.type(input, 'ban');
           await waitFor(async () => {
-            expect( queryByText('banana')).toBeTruthy();
-            expect( queryByText('avocado')).toBeFalsy();
-            expect( queryByText('orange')).toBeFalsy();
+            expect(queryByText('banana')).toBeTruthy();
+            expect(queryByText('avocado')).toBeFalsy();
+            expect(queryByText('orange')).toBeFalsy();
           })
         });
       });
-      
-  
+
+
       it('should render the Dropdown component by default', async () => {
-        render(<Dropdown asyncOptions={() => Promise.resolve(options)}  mode="nested" defaultOptions />);
+        render(<Dropdown asyncOptions={() => Promise.resolve(options)} mode="nested" defaultOptions />);
         const input = screen.getByRole('textbox');
         userEvent.click(input);
         await waitFor(async () => {
           const nestedItem = screen.getByText('banana');
           expect(nestedItem.classList.contains('tk-select__option--nested')).toBeTruthy();
         })
-        
+
       });
-      
+
       it('should show/hide options menu', async () => {
-        const { getByText } =   render(<Dropdown asyncOptions={() => Promise.resolve(options)} hideSelectedOptions closeMenuOnSelect enableTermSearch defaultOptions/>);
-        const input =  screen.getByRole('textbox');
+        const { getByText } = render(<Dropdown asyncOptions={() => Promise.resolve(options)} hideSelectedOptions closeMenuOnSelect enableTermSearch defaultOptions />);
+        const input = screen.getByRole('textbox');
         userEvent.click(input);
         await waitFor(async () => {
-          expect( getByText('banana')).toBeTruthy();
-          expect( getByText('avocado')).toBeTruthy();
-          expect( getByText('orange')).toBeTruthy();
+          expect(getByText('banana')).toBeTruthy();
+          expect(getByText('avocado')).toBeTruthy();
+          expect(getByText('orange')).toBeTruthy();
         })
-  
+
       });
-      
+
       it('should select first option', async () => {
-        const { getByText } = render(<Dropdown asyncOptions={() => Promise.resolve(options)} noOptionMessage="no options message"/>);
+        const { getByText } = render(<Dropdown asyncOptions={() => Promise.resolve(options)} noOptionMessage="no options message" />);
         const input = screen.getByRole('textbox');
         userEvent.click(input);
         await waitFor(async () => {
@@ -362,7 +362,7 @@ describe('Dropdown component test suite =>', () => {
           expect(screen.getByText('no options message')).toBeTruthy();
         })
       });
-      
+
       it('should render costum render dropdown', async () => {
         const { container, getByText } = render(
           <Dropdown
@@ -389,16 +389,16 @@ describe('Dropdown component test suite =>', () => {
         expect(getByText('Select...')).toBeTruthy();
       });
     });
-  
+
     describe('when is Multiselect', () => {
-  
+
       it('should render the Multiselect component by default', async () => {
-        const { getByText } = render(<Dropdown  asyncOptions={() => Promise.resolve(options)} isMultiSelect />);
+        const { getByText } = render(<Dropdown asyncOptions={() => Promise.resolve(options)} isMultiSelect />);
         expect(getByText('Select...')).toBeInTheDocument();
       });
-      
+
       it('should show/hide options menu', async () => {
-        const { getByText } = render(<Dropdown  asyncOptions={() => Promise.resolve(options)} isMultiSelect filterFunction={filterFunction}/>);
+        const { getByText } = render(<Dropdown asyncOptions={() => Promise.resolve(options)} isMultiSelect filterFunction={filterFunction} />);
         const input = screen.getByRole('textbox');
         userEvent.click(input);
         await waitFor(async () => {
@@ -407,7 +407,7 @@ describe('Dropdown component test suite =>', () => {
           expect(getByText('orange')).toBeTruthy();
         })
       });
-      
+
       it('should select first option', async () => {
         const { getByText } = render(<Dropdown asyncOptions={() => Promise.resolve(options)} isMultiSelect />);
         const input = screen.getByRole('textbox');
@@ -418,9 +418,9 @@ describe('Dropdown component test suite =>', () => {
           expect(getByText('banana')).toBeTruthy();
         })
       });
-  
-      it('should clean selection', async() => {
-        const { getByText, container} = render(<Dropdown asyncOptions={() => Promise.resolve(options)} isMultiSelect />);
+
+      it('should clean selection', async () => {
+        const { getByText, container } = render(<Dropdown asyncOptions={() => Promise.resolve(options)} isMultiSelect />);
         const input = screen.getByRole('textbox');
         userEvent.click(input);
         await waitFor(async () => {
@@ -431,8 +431,8 @@ describe('Dropdown component test suite =>', () => {
           expect(getByText('Select...')).toBeTruthy();
         })
       });
-      
-      
+
+
       it('should render custom render dropdown', async () => {
         const { getByText } = render(
           <Dropdown
@@ -452,7 +452,7 @@ describe('Dropdown component test suite =>', () => {
         })
       });
     });
-  
+
     describe('when search by term is enabled', () => {
       it('should render the header option when user starts typing', async () => {
         const { queryByText } = render(
@@ -465,15 +465,15 @@ describe('Dropdown component test suite =>', () => {
         );
 
         const input = screen.getByRole('textbox');
-        userEvent.type(input,'B');
+        userEvent.type(input, 'B');
         await waitFor(async () => {
           expect(queryByText(/Search for term/)).toBeInTheDocument();
         })
       });
-   
+
       it('should select option header', async () => {
-        const searchedTerm ='BBBmous';
-        const {  getByText, queryByText } = render(
+        const searchedTerm = 'BBBmous';
+        const { getByText, queryByText } = render(
           <Dropdown
             isOptionDisabled={optionDisabled}
             isOptionSelected={optionSelected}
@@ -487,16 +487,16 @@ describe('Dropdown component test suite =>', () => {
         );
         const input = screen.getByRole('textbox');
         await waitFor(async () => {
-          userEvent.type(input,searchedTerm);
+          userEvent.type(input, searchedTerm);
           fireEvent.mouseDown(input);
-          //Select header option 
+          //Select header option
           fireEvent.click(queryByText(/Search for term/));
           expect(getByText('BBBmousBBBmous')).toBeInTheDocument();
         })
 
       });
     });
-    
+
     describe('when is with Validation Component', () => {
       it('should be triggered on Blur and on Change', async () => {
         const { getByText } = render(<>
@@ -531,5 +531,5 @@ describe('Dropdown component test suite =>', () => {
       });
     });
   });
-  
+
 });

--- a/src/components/input/InputDecorator.tsx
+++ b/src/components/input/InputDecorator.tsx
@@ -38,7 +38,9 @@ const InputDecorator: React.FC<InputDecoratorProps> = ({
   showRequired,
   className,
   children,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onInit,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onValidationChanged,
   ...rest
 }) => {

--- a/src/components/input/TextComponent.tsx
+++ b/src/components/input/TextComponent.tsx
@@ -103,6 +103,7 @@ const TextComponent: React.FC<
       onClick,
       onFocus,
       onKeyDown,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       onValidationChanged,
       ...rest
     },

--- a/src/components/selection/SelectionInput.tsx
+++ b/src/components/selection/SelectionInput.tsx
@@ -40,6 +40,7 @@ const SelectionInput: React.FC<SelectionInputPropsWithType> = ({
   disabled,
   tabIndex,
   status,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onInit,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onValidationChanged,
@@ -108,12 +109,6 @@ const SelectionInput: React.FC<SelectionInputPropsWithType> = ({
   useEffect(() => {
     setIsChecked(getCheckedValue(status));
   }, [status]);
-
-  useEffect(() => {
-    if (onInit) {
-      onInit(isChecked);
-    }
-  }, []);
 
   // Component gets focus
   const onFocusHandler = () => {

--- a/src/components/selection/SelectionInput.tsx
+++ b/src/components/selection/SelectionInput.tsx
@@ -7,6 +7,7 @@ import SelectionTypes, { SelectionInputTypes } from './SelectionTypes';
 import SelectionStatus, { getCheckedValue } from './SelectionStatus';
 import LabelPlacements from './LabelPlacements';
 import { Keys } from '../common/keyUtils';
+import { HasValidationProps } from '../validation/interfaces';
 
 interface SelectionInputProps {
   id?: string;
@@ -22,9 +23,9 @@ interface SelectionInputProps {
   tabIndex?: number;
 }
 
-interface SelectionInputPropsWithType extends SelectionInputProps {
-  type: SelectionTypes;
-}
+type SelectionInputPropsWithType = {
+  type: SelectionTypes,
+} & SelectionInputProps & HasValidationProps<string>
 
 const SelectionInput: React.FC<SelectionInputPropsWithType> = ({
   id,
@@ -39,6 +40,9 @@ const SelectionInput: React.FC<SelectionInputPropsWithType> = ({
   disabled,
   tabIndex,
   status,
+  onInit,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  onValidationChanged,
   ...otherProps
 }) => {
   // Generate unique ID if not provided
@@ -104,6 +108,12 @@ const SelectionInput: React.FC<SelectionInputPropsWithType> = ({
   useEffect(() => {
     setIsChecked(getCheckedValue(status));
   }, [status]);
+
+  useEffect(() => {
+    if (onInit) {
+      onInit(isChecked);
+    }
+  }, []);
 
   // Component gets focus
   const onFocusHandler = () => {
@@ -196,6 +206,7 @@ const SelectionInputPropTypes = {
   status: PropTypes.oneOf(Object.values(SelectionStatus)),
   onClick: PropTypes.func,
   onChange: PropTypes.func,
+  onInit: PropTypes.func,
   required: PropTypes.bool,
   disabled: PropTypes.bool,
   tabIndex: PropTypes.number,

--- a/stories/Validation.stories.tsx
+++ b/stories/Validation.stories.tsx
@@ -129,7 +129,7 @@ export const Validations = () => {
           onChange={(e) => {
             setDate(e.target.value);
           }}
-        ></DatePicker>
+        />
       </Validation>
       <h3>Dropdown</h3>
       <p>
@@ -151,7 +151,7 @@ export const Validations = () => {
             setDropdown(e.target.value);
           }}
           isInputClearable
-        ></Dropdown>
+        />
       </Validation>
       <Validation
         onValidationChanged={logChange}
@@ -170,7 +170,7 @@ export const Validations = () => {
             setMultiDropdown(e.target.value);
           }}
           isMultiSelect
-        ></Dropdown>
+        />
       </Validation>
       <h3>InputDecorator</h3>
       <p>
@@ -343,7 +343,7 @@ export const Validations = () => {
           onChange={(e) => {
             setDate(e.target.value);
           }}
-        ></DatePicker>
+        />
       </Validation>
       <p>Another example with the TimePicker :</p>
       <Validation


### PR DESCRIPTION
**Jira ticket**
https://perzoinc.atlassian.net/browse/APP-4317

**Change:**
Fix not supported property on Checkbox and fix lint warnings

Description: Some props are automatically injected by the Validation Component and are not used in Native HTML tags (like the input). So, I mark them as unused variables in the Component and don't inject them in the native input.

Before the fix:

![Screen Shot 2021-07-09 at 11 19 04](https://user-images.githubusercontent.com/66668470/126303515-f1a0bd66-6bf9-41f6-9f4a-e194ec3653f6.png)

With the fix:

![Screenshot 2021-07-20 at 11 54 55](https://user-images.githubusercontent.com/66668470/126303732-71ebdfc3-ecca-4393-8fb5-39b342144fdf.png)
