### PR TITLE
APP-4191 Select only one option if they have the same value

### DIFF
--- a/spec/components/dropdown/Dropdown.spec.tsx
+++ b/spec/components/dropdown/Dropdown.spec.tsx
@@ -532,4 +532,23 @@ describe('Dropdown component test suite =>', () => {
     });
   });
 
+  describe('when there are several options with same value', () => {
+    it('should select only one option', () => {
+      const options: LabelValue[] = [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '1' },
+        { label: 'Option 3 ', value: '1' },
+      ];
+      
+      render(<Dropdown options={options}/>);
+      const input = screen.getByRole('textbox');
+      userEvent.click(input);
+      userEvent.click(screen.getByText('Option 1'));
+      userEvent.click(input);
+      // First reference is the selected option on the input
+      expect(screen.getAllByText('Option 1')[1].classList.contains('tk-select__option--is-selected')).toBeTruthy();
+      expect(screen.getByText('Option 2').classList.contains('tk-select__option--is-selected')).toBeFalsy();
+      expect(screen.getByText('Option 3').classList.contains('tk-select__option--is-selected')).toBeFalsy();
+    }); 
+  });
 });

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -236,7 +236,7 @@ export class Dropdown<T = LabelValue> extends React.Component<
 
   handleIsOptionSelected = this.props.isOptionSelected
     ? (option: any) => this.props.isOptionSelected(option.data)
-    : undefined;
+    :  (option: DropdownOption<T>, selectValue: any) => selectValue?.some(i => i === option);
 
   get internalOptions() {
     if (this.props?.options) {
@@ -324,6 +324,7 @@ export class Dropdown<T = LabelValue> extends React.Component<
             valueContainer: provided => ({
               ...provided,  maxHeight:`${maxHeight}px`})
           }}
+          // isOptionSelected={(option, selectValue) => selectValue.some(i => i === option)}
           parentInstance={this}
           ref={this.myRef}
           selectRef={this.myRef}

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -324,7 +324,6 @@ export class Dropdown<T = LabelValue> extends React.Component<
             valueContainer: provided => ({
               ...provided,  maxHeight:`${maxHeight}px`})
           }}
-          // isOptionSelected={(option, selectValue) => selectValue.some(i => i === option)}
           parentInstance={this}
           ref={this.myRef}
           selectRef={this.myRef}

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -236,7 +236,7 @@ export class Dropdown<T = LabelValue> extends React.Component<
 
   handleIsOptionSelected = this.props.isOptionSelected
     ? (option: any) => this.props.isOptionSelected(option.data)
-    :  (option: DropdownOption<T>, selectValue: any) => selectValue?.some(i => i === option);
+    :  (option: DropdownOption<T>, selectValue: T[]) => selectValue?.some(i => i === option);
 
   get internalOptions() {
     if (this.props?.options) {


### PR DESCRIPTION
### Description 

When several options had the same value and the user selects one of them, they were all marked as selected. 

<img width="977" alt="Screenshot 2021-07-21 at 11 14 44" src="https://user-images.githubusercontent.com/68587873/126463972-452b8731-d53b-4215-a668-744db1efa8db.png">


### Fix
When several options had the same value and the user selects one of them, there is only one displayed as selected. 

<img width="739" alt="Screenshot 2021-07-21 at 11 16 25" src="https://user-images.githubusercontent.com/68587873/126464241-38a3133d-b86d-4aab-9220-6c4394a4b336.png">

[Jira ticket](https://perzoinc.atlassian.net/browse/APP-4191)
