### PR TITLE
EIS-3537 - Badge default variant

### DIFF
--- a/spec/components/badge/Badge.spec.tsx
+++ b/spec/components/badge/Badge.spec.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 
-import Badge from '../../../src/components/badge/Badge';
+import {Badge} from '../../../src/components/badge';
 
 describe('Badge Component', () => {
   it('render with default props does not crash', () => {
     const wrapper = shallow(<Badge>Text</Badge>);
     expect(wrapper.length).toEqual(1);
     expect(wrapper.hasClass('tk-badge')).toBe(true);
+    expect(wrapper.find('div').hasClass('tk-badge--default')).toBe(true);
   });
   it('render a variant', () => {
     const wrapper = shallow(<Badge variant="attention">Badge</Badge>);

--- a/src/components/badge/Badge.tsx
+++ b/src/components/badge/Badge.tsx
@@ -1,16 +1,9 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { BadgeProps } from './interfaces';
 
 const prefix = 'tk-badge';
-
-export interface BadgeProps extends React.HTMLProps<HTMLDivElement>  {
-  /** Content of the badge */
-  children?: React.ReactNode;
-  className?: string;
-  /** The variant to use */
-  variant?: 'positive' | 'neutral' | 'attention' | 'warning' | 'external';
-}
 
 const Badge: React.FC<BadgeProps> = ({
   children,
@@ -33,11 +26,14 @@ const Badge: React.FC<BadgeProps> = ({
   );
 };
 
+Badge.defaultProps = {
+  variant:'default',  
+}
 
 Badge.propTypes = {
   children: PropTypes.any,
   className: PropTypes.string,
-  variant: PropTypes.oneOf(['positive', 'neutral', 'attention', 'warning', 'external']),
+  variant: PropTypes.oneOf(['default', 'positive' , 'neutral' , 'attention' , 'warning' , 'external']),
 }
 Badge.displayName = 'Badge';
 export default Badge;

--- a/src/components/badge/index.ts
+++ b/src/components/badge/index.ts
@@ -1,3 +1,3 @@
 import Badge from './Badge';
 
-export default Badge;
+export { Badge };

--- a/src/components/badge/interfaces.ts
+++ b/src/components/badge/interfaces.ts
@@ -1,0 +1,8 @@
+export type BadgeProps = {
+  /** Content of the badge */
+  children?: React.ReactNode;
+  className?: string;
+  /** The variant to use */
+  variant?: 'default' | 'positive' | 'neutral' | 'attention' | 'warning' | 'external';
+}
+

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -23,10 +23,10 @@ import Tooltip, { TooltipProps } from './tooltip';
 import Typography from './typography';
 import Validation from './validation';
 import VirtualizedList from './virtualized-list';
-import Badge from './badge';
 
 /* Let's move into exporting everything with interfaces */
 export * from './avatar';
+export * from './badge';
 export * from './banner';
 export * from './button';
 export * from './dropdown';
@@ -60,5 +60,4 @@ export {
   ModalFooter,
   Typography,
   Loader,
-  Badge,
 };

--- a/stories/Badge.stories.tsx
+++ b/stories/Badge.stories.tsx
@@ -11,8 +11,25 @@ export const Default = Template.bind({});
 
 Default.args = {
   children: 'Some Text',
-  variant: ''
 };
+
+export const DefaultVariant: React.FC = () => (
+  <>
+    <Badge variant="default" className="tk-mr-h">Badge</Badge>
+    <Badge variant="default">
+      <Icon iconName="bot" className="tk-mr-h"></Icon>
+        Badge
+    </Badge>
+  </>);
+
+export const Positive: React.FC = () => (
+  <>
+    <Badge variant="positive" className="tk-mr-h">Badge</Badge>
+    <Badge variant="positive">
+      <Icon iconName="announce" className="tk-mr-h"></Icon>
+        Badge
+    </Badge>
+  </>);
 
 export const Neutral: React.FC = () => (
   <>


### PR DESCRIPTION
- added "default" as a value for the variant prop
- created a BadgeType type
- reorganised files to be consistent with Banner implementation

IMO it is better to have a BadgeType enum instead of hardcoded strings.
It shouldn't be a breaking change as the values of the enum are kept.

the style is now correctly defined:
![Screenshot 2021-07-22 at 12 24 00](https://user-images.githubusercontent.com/54842163/126625587-112e57a8-a2d2-4df4-9f26-59d9cdfe4491.png)

and we can change on the fly:
![Screenshot 2021-07-22 at 12 23 18](https://user-images.githubusercontent.com/54842163/126625589-4e8e205a-6697-480b-a546-ec9c8767b0cf.png)
