### PR TITLE
APP-3334 - Adding TextEllipsis

### DIFF
--- a/spec/components/text-ellipsis/TextEllipsis.spec.tsx
+++ b/spec/components/text-ellipsis/TextEllipsis.spec.tsx
@@ -7,7 +7,7 @@ import { TextEllipsis } from '../../../src/components';
 
 describe.only('TextEllipsis', () => {
 
-  it('should apply tk-text-ellipsis__multiple-rows when number of rows are more than 1', () => {
+  it('should apply tk-text-ellipsis--multiple-rows when number of rows are more than 1', () => {
     render(
       <TextEllipsis rows={ 2 } tooltipPlacement="bottom">
         { 'Really, really, really, really, really, long text that gets cut!' }
@@ -15,7 +15,7 @@ describe.only('TextEllipsis', () => {
     )
 
     const element = screen.queryByText('Really, really, really, really, really, long text that gets cut!')
-    element.classList.contains('tk-text-ellipsis__multiple-rows')
+    element.classList.contains('tk-text-ellipsis--multiple-rows')
   })
 
 });

--- a/spec/components/text-ellipsis/TextEllipsis.spec.tsx
+++ b/spec/components/text-ellipsis/TextEllipsis.spec.tsx
@@ -7,17 +7,6 @@ import { TextEllipsis } from '../../../src/components';
 
 describe.only('TextEllipsis', () => {
 
-  it('should apply tk-text-ellipsis__single-row when number of rows are equal to 1', () => {
-    render(
-      <TextEllipsis rows={ 1 } tooltipPlacement="bottom">
-        { 'Really, really, really, really, really, long text that gets cut!' }
-      </TextEllipsis>
-    )
-    
-    const element = screen.queryByText('Really, really, really, really, really, long text that gets cut!')
-    element.classList.contains('tk-text-ellipsis__single-row')
-  })
-
   it('should apply tk-text-ellipsis__multiple-rows when number of rows are more than 1', () => {
     render(
       <TextEllipsis rows={ 2 } tooltipPlacement="bottom">
@@ -28,4 +17,5 @@ describe.only('TextEllipsis', () => {
     const element = screen.queryByText('Really, really, really, really, really, long text that gets cut!')
     element.classList.contains('tk-text-ellipsis__multiple-rows')
   })
+
 });

--- a/spec/components/text-ellipsis/TextEllipsis.spec.tsx
+++ b/spec/components/text-ellipsis/TextEllipsis.spec.tsx
@@ -5,11 +5,31 @@ import {
 } from '@testing-library/react';
 import { TextEllipsis } from '../../../src/components';
 
-describe.only('TextEllipsis', () => {
+describe('TextEllipsis', () => {
+
+  it('should create a tooltip when tooltipOnEllipsis is true', () => {
+    render(
+      <TextEllipsis rows={ 1 }>
+        { 'Really, really, really, really, really, long text that gets cut!' }
+      </TextEllipsis>
+    )
+    const elements = document.querySelectorAll('span')
+    expect(elements.length).toBe(2)
+  });
+
+  it('should not create a tooltip when tooltipOnEllipsis is false', () => {
+    render(
+      <TextEllipsis tooltipOnEllipsis={false}>
+        { 'Really, really, really, really, really, long text that gets cut!' }
+      </TextEllipsis>      
+    )
+    const elements = document.querySelectorAll('span')
+    expect(elements.length).toBe(0)
+  });
 
   it('should apply tk-text-ellipsis--multiple-rows when number of rows are more than 1', () => {
     render(
-      <TextEllipsis rows={ 2 } tooltipPlacement="bottom">
+      <TextEllipsis rows={ 2 }>
         { 'Really, really, really, really, really, long text that gets cut!' }
       </TextEllipsis>
     )

--- a/spec/components/text-ellipsis/TextEllipsis.spec.tsx
+++ b/spec/components/text-ellipsis/TextEllipsis.spec.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import {
+  render,
+  screen,
+} from '@testing-library/react';
+import { TextEllipsis } from '../../../src/components';
+
+describe.only('TextEllipsis', () => {
+
+  it('should apply tk-text-ellipsis__single-row when number of rows are equal to 1', () => {
+    render(
+      <TextEllipsis rows={ 1 } tooltipPlacement="bottom">
+        { 'Really, really, really, really, really, long text that gets cut!' }
+      </TextEllipsis>
+    )
+    
+    const element = screen.queryByText('Really, really, really, really, really, long text that gets cut!')
+    element.classList.contains('tk-text-ellipsis__single-row')
+  })
+
+  it('should apply tk-text-ellipsis__multiple-rows when number of rows are more than 1', () => {
+    render(
+      <TextEllipsis rows={ 2 } tooltipPlacement="bottom">
+        { 'Really, really, really, really, really, long text that gets cut!' }
+      </TextEllipsis>
+    )
+
+    const element = screen.queryByText('Really, really, really, really, really, long text that gets cut!')
+    element.classList.contains('tk-text-ellipsis__multiple-rows')
+  })
+});

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -30,6 +30,7 @@ export * from './badge';
 export * from './banner';
 export * from './button';
 export * from './dropdown';
+export * from './text-ellipsis';
 export * from './nav';
 export * from './time-picker';
 export * from './toast';

--- a/src/components/text-ellipsis/TextEllipsis.tsx
+++ b/src/components/text-ellipsis/TextEllipsis.tsx
@@ -19,10 +19,6 @@ interface TextEllipsisProps extends Omit<React.HTMLProps<HTMLDivElement>, 'type'
       | 'top'
 }
 
-interface TextEllipsisState {
-    showTooltip: boolean;
-}
-
 export const TextEllipsis: React.FC<TextEllipsisProps> = ({
   children,
   rows,
@@ -43,6 +39,21 @@ export const TextEllipsis: React.FC<TextEllipsisProps> = ({
     setShowTooltip(false);
   }
 
+  const getTextEllipsisHTML = () => {
+    return (<div
+      className={ classnames(
+        'tk-text-ellipsis', {
+          'tk-text-ellipsis__multiple-rows': rows > 1
+        }) }
+      style={{ WebkitLineClamp: rows}}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...otherProps}
+    >
+      { children }
+    </div>)
+  }
+
   if(tooltipOnEllipsis) {
     return(
       <Tooltip
@@ -51,34 +62,12 @@ export const TextEllipsis: React.FC<TextEllipsisProps> = ({
         type="tooltip"
         visible={showTooltip}
       >
-        <div
-          className={ classnames(
-            'tk-text-ellipsis', {
-              'tk-text-ellipsis__multiple-rows': rows > 1
-            }) }
-          style={{ WebkitLineClamp: rows}}
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
-          {...otherProps}
-        >
-          { children }
-        </div>
+        {getTextEllipsisHTML()}
       </Tooltip>
     )
   } else {
     return(
-      <div
-        className={ classnames(
-          'tk-text-ellipsis', {
-            'tk-text-ellipsis__multiple-rows': rows > 1
-          }) }
-        style={{ WebkitLineClamp: rows}}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-        {...otherProps}
-      >
-        { children }
-      </div>
+      getTextEllipsisHTML()
     )
   }
 }

--- a/src/components/text-ellipsis/TextEllipsis.tsx
+++ b/src/components/text-ellipsis/TextEllipsis.tsx
@@ -64,7 +64,7 @@ export const TextEllipsis: React.FC<TextEllipsisProps> = ({
         className={ classnames(
           'tk-text-ellipsis', {
             'tk-text-ellipsis__single-row': rows === 1,
-            'tk-text-ellipsis__multiple_rows': rows > 1
+            'tk-text-ellipsis__multiple-rows': rows > 1
           }) }
         style={{ WebkitLineClamp: rows}}
         onMouseEnter={handleMouseEnter}

--- a/src/components/text-ellipsis/TextEllipsis.tsx
+++ b/src/components/text-ellipsis/TextEllipsis.tsx
@@ -9,7 +9,10 @@ interface TextEllipsisProps extends Omit<React.HTMLProps<HTMLDivElement>, 'type'
     /** How many rows the text should span before ellipsing */
     rows?: number;
 
-    tooltipPlacement:
+    /** Wheather a tooltip should be shown on hover when the text is ellipsed */
+    tooltipOnEllipsis?: boolean;
+
+    tooltipPlacement?:
       | 'bottom'
       | 'left'
       | 'right'
@@ -23,23 +26,12 @@ interface TextEllipsisState {
 export const TextEllipsis: React.FC<TextEllipsisProps> = ({
   children,
   rows,
+  tooltipOnEllipsis,
   tooltipPlacement,
   ...otherProps
 }: TextEllipsisProps) => {
 
   const [showTooltip, setShowTooltip] = React.useState(false);
-
-  const isTextTruncated = (element: EventTarget & Element) => {
-    const { scrollWidth, scrollHeight, clientWidth, clientHeight} = element;
-
-    if(scrollHeight > clientHeight) {
-      return true
-    } else if(scrollWidth > clientWidth) {
-      return true;
-    } else {
-      return false
-    }
-  }
 
   const handleMouseEnter = (event: React.SyntheticEvent) => {
     const element = event.currentTarget;
@@ -51,13 +43,30 @@ export const TextEllipsis: React.FC<TextEllipsisProps> = ({
     setShowTooltip(false);
   }
 
-  return(
-    <Tooltip
-      description={ children as JSX.Element }
-      placement={tooltipPlacement}
-      type="tooltip"
-      visible={showTooltip}
-    >
+  if(tooltipOnEllipsis) {
+    return(
+      <Tooltip
+        description={ children as JSX.Element }
+        placement={tooltipPlacement || 'bottom'}
+        type="tooltip"
+        visible={showTooltip}
+      >
+        <div
+          className={ classnames(
+            'tk-text-ellipsis', {
+              'tk-text-ellipsis__multiple-rows': rows > 1
+            }) }
+          style={{ WebkitLineClamp: rows}}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+          {...otherProps}
+        >
+          { children }
+        </div>
+      </Tooltip>
+    )
+  } else {
+    return(
       <div
         className={ classnames(
           'tk-text-ellipsis', {
@@ -70,11 +79,23 @@ export const TextEllipsis: React.FC<TextEllipsisProps> = ({
       >
         { children }
       </div>
-    </Tooltip>
-  )
+    )
+  }
 }
 
 TextEllipsis.defaultProps = {
   rows: 1,
   tooltipPlacement: 'top',
+}
+
+const isTextTruncated = (element: EventTarget & Element) => {
+  const { scrollWidth, scrollHeight, clientWidth, clientHeight} = element;
+
+  if(scrollHeight > clientHeight) {
+    return true
+  } else if(scrollWidth > clientWidth) {
+    return true;
+  } else {
+    return false
+  }
 }

--- a/src/components/text-ellipsis/TextEllipsis.tsx
+++ b/src/components/text-ellipsis/TextEllipsis.tsx
@@ -9,9 +9,6 @@ interface TextEllipsisProps extends Omit<React.HTMLProps<HTMLDivElement>, 'type'
     /** How many rows the text should span before ellipsing */
     rows?: number;
 
-    /** Needed? Add description */
-    textRef?: React.RefObject<HTMLElement>;
-
     tooltipPlacement:
       | 'bottom'
       | 'left'
@@ -26,7 +23,6 @@ interface TextEllipsisState {
 export const TextEllipsis: React.FC<TextEllipsisProps> = ({
   children,
   rows,
-  textRef,
   tooltipPlacement,
   ...otherProps
 }: TextEllipsisProps) => {
@@ -34,13 +30,8 @@ export const TextEllipsis: React.FC<TextEllipsisProps> = ({
   const [showTooltip, setShowTooltip] = React.useState(false);
 
   const isTextTruncated = (element: EventTarget & Element) => {    
-    if (textRef?.current) {
-      const { scrollWidth, clientWidth } = textRef.current;
-      return scrollWidth > clientWidth;
-    } else {
-      const { scrollWidth, clientWidth } = element;
-      return scrollWidth > clientWidth;
-    }
+    const { scrollWidth, clientWidth } = element;
+    return scrollWidth > clientWidth;
   }
 
   const handleMouseEnter = (event: React.SyntheticEvent) => {

--- a/src/components/text-ellipsis/TextEllipsis.tsx
+++ b/src/components/text-ellipsis/TextEllipsis.tsx
@@ -63,7 +63,6 @@ export const TextEllipsis: React.FC<TextEllipsisProps> = ({
       <div
         className={ classnames(
           'tk-text-ellipsis', {
-            'tk-text-ellipsis__single-row': rows === 1,
             'tk-text-ellipsis__multiple-rows': rows > 1
           }) }
         style={{ WebkitLineClamp: rows}}

--- a/src/components/text-ellipsis/TextEllipsis.tsx
+++ b/src/components/text-ellipsis/TextEllipsis.tsx
@@ -79,12 +79,5 @@ TextEllipsis.defaultProps = {
 
 const isTextTruncated = (element: EventTarget & Element) => {
   const { scrollWidth, scrollHeight, clientWidth, clientHeight} = element;
-
   return (scrollHeight > clientHeight) || (scrollWidth > clientWidth)
-    return true
-  } else if(scrollWidth > clientWidth) {
-    return true;
-  } else {
-    return false
-  }
 }

--- a/src/components/text-ellipsis/TextEllipsis.tsx
+++ b/src/components/text-ellipsis/TextEllipsis.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import Tooltip from '../tooltip';
+
+type TextEllipsisProps = {
+    /** Text that should be ellipsed */
+    children?: React.ReactNode;
+
+    /** How many rows the text should span before ellipsing */
+    rows?: number;
+
+    /** Should be same as children, for now separate */
+    tooltipContent: string | JSX.Element;
+
+    /** Needed? Add description */
+    textRef?: React.RefObject<HTMLElement>;
+
+    tooltipPlacement:
+      | 'bottom'
+      | 'left'
+      | 'right'
+      | 'top'
+};
+
+interface TextEllipsisState {
+    showTooltip: boolean;
+}
+
+export class TextEllipsis extends React.Component<
+    TextEllipsisProps,
+    TextEllipsisState
+> {
+  
+  constructor(props: TextEllipsisProps) {
+    super(props);
+    this.state = {
+      showTooltip: false,
+    };
+  }
+
+  public render() {
+    const { showTooltip } = this.state;
+
+    return (
+      <Tooltip
+        description={ this.renderTooltipContent()}
+        placement={this.props.tooltipPlacement}
+        open={showTooltip}
+      >
+        <div
+          onMouseEnter={this.handleMouseEnter}
+          onMouseLeave={this.handleMouseLeave}
+          data-testid="TEXT_ELLIPSIS_CONTAINER"
+        >
+          { this.props.children }
+        </div>
+      </Tooltip>
+    );
+  }
+
+  private renderTooltipContent() {
+    return (
+      <span>
+        {this.props.tooltipContent}
+      </span>
+    );
+  }
+  private handleMouseEnter = (event: React.SyntheticEvent) => {
+    const element = event.currentTarget;
+    const showTooltip = this.isTextTruncated(element);
+    this.setState({ showTooltip })
+  }
+
+  private handleMouseLeave = () => {
+    this.setState({ showTooltip: false });
+  }
+
+  private isTextTruncated(element: EventTarget & Element) {
+    const { textRef } = this.props;
+    if (textRef && textRef.current) {
+      const { scrollWidth, clientWidth } = textRef.current;
+      return scrollWidth > clientWidth;
+    } else {
+      const { scrollWidth, clientWidth } = element.children[0];
+      return scrollWidth > clientWidth;
+    }
+  }
+}

--- a/src/components/text-ellipsis/TextEllipsis.tsx
+++ b/src/components/text-ellipsis/TextEllipsis.tsx
@@ -29,9 +29,16 @@ export const TextEllipsis: React.FC<TextEllipsisProps> = ({
 
   const [showTooltip, setShowTooltip] = React.useState(false);
 
-  const isTextTruncated = (element: EventTarget & Element) => {    
-    const { scrollWidth, clientWidth } = element;
-    return scrollWidth > clientWidth;
+  const isTextTruncated = (element: EventTarget & Element) => {
+    const { scrollWidth, scrollHeight, clientWidth, clientHeight} = element;
+
+    if(scrollHeight > clientHeight) {
+      return true
+    } else if(scrollWidth > clientWidth) {
+      return true;
+    } else {
+      return false
+    }
   }
 
   const handleMouseEnter = (event: React.SyntheticEvent) => {

--- a/src/components/text-ellipsis/TextEllipsis.tsx
+++ b/src/components/text-ellipsis/TextEllipsis.tsx
@@ -43,7 +43,7 @@ export const TextEllipsis: React.FC<TextEllipsisProps> = ({
     return (<div
       className={ classnames(
         'tk-text-ellipsis', {
-          'tk-text-ellipsis__multiple-rows': rows > 1
+          'tk-text-ellipsis--multiple-rows': rows > 1
         }) }
       style={{ WebkitLineClamp: rows}}
       onMouseEnter={handleMouseEnter}

--- a/src/components/text-ellipsis/TextEllipsis.tsx
+++ b/src/components/text-ellipsis/TextEllipsis.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import classnames from 'classnames';
 import Tooltip from '../tooltip';
 
-interface TextEllipsisProps extends React.HTMLProps<HTMLDivElement> {
+interface TextEllipsisProps extends Omit<React.HTMLProps<HTMLDivElement>, 'type'> {
     /** Text that should be ellipsed */
     children?: React.ReactNode;
 
@@ -56,7 +56,7 @@ export const TextEllipsis: React.FC<TextEllipsisProps> = ({
   return(
     <Tooltip
       description={ children as JSX.Element }
-      placement={'bottom'}
+      placement={tooltipPlacement}
       type="tooltip"
       visible={showTooltip}
     >
@@ -69,6 +69,7 @@ export const TextEllipsis: React.FC<TextEllipsisProps> = ({
         style={{ WebkitLineClamp: rows}}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
+        {...otherProps}
       >
         { children }
       </div>

--- a/src/components/text-ellipsis/TextEllipsis.tsx
+++ b/src/components/text-ellipsis/TextEllipsis.tsx
@@ -80,7 +80,7 @@ TextEllipsis.defaultProps = {
 const isTextTruncated = (element: EventTarget & Element) => {
   const { scrollWidth, scrollHeight, clientWidth, clientHeight} = element;
 
-  if(scrollHeight > clientHeight) {
+  return (scrollHeight > clientHeight) || (scrollWidth > clientWidth)
     return true
   } else if(scrollWidth > clientWidth) {
     return true;

--- a/src/components/text-ellipsis/TextEllipsis.tsx
+++ b/src/components/text-ellipsis/TextEllipsis.tsx
@@ -75,6 +75,7 @@ export const TextEllipsis: React.FC<TextEllipsisProps> = ({
 TextEllipsis.defaultProps = {
   rows: 1,
   tooltipPlacement: 'top',
+  tooltipOnEllipsis: true,
 }
 
 const isTextTruncated = (element: EventTarget & Element) => {

--- a/src/components/text-ellipsis/index.ts
+++ b/src/components/text-ellipsis/index.ts
@@ -1,0 +1,1 @@
+export { TextEllipsis } from './TextEllipsis';

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -13,6 +13,7 @@ import { showTooltipOnClick, showTooltipOnHover } from './helpers';
 
 const SpanStyled = styled.span`
   display: inline-block;
+  max-width: 100%;
 `;
 
 const TooltipContainer = styled.div`
@@ -141,7 +142,7 @@ const Tooltip: React.FC<TooltipProps> = ({
     ],
   });
 
-  const children = <span>{otherProps.children}</span>;
+  const children = <>{otherProps.children}</>;
 
   const isVisible =
     typeof visible !== 'undefined'
@@ -212,8 +213,7 @@ Tooltip.defaultProps = {
 
 Tooltip.propTypes = {
   closeLabel: PropTypes.string,
-  description: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
-    .isRequired,
+  description: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
   displayTrigger: PropTypes.oneOf(['click', 'hover']),
   id: PropTypes.string,
   onHintClose: PropTypes.func,

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -142,7 +142,7 @@ const Tooltip: React.FC<TooltipProps> = ({
     ],
   });
 
-  const children = <>{otherProps.children}</>;
+  const children = <span>{otherProps.children}</span>;
 
   const isVisible =
     typeof visible !== 'undefined'

--- a/stories/TextEllipsis.stories.tsx
+++ b/stories/TextEllipsis.stories.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import {
+  TextEllipsis
+} from '../src/components';
+
+export default {
+  title: 'Components/Ellipsed Text',
+  component: TextEllipsis,
+};
+
+const Template = (args) => {
+  return (
+    <div>
+      <TextEllipsis tooltipContent={ 'asdasd '} expand={ true} rows={ 1 } {...args}>
+        { 'Hello Axel, here is a really, really long text!'}
+      </TextEllipsis>
+    </div>
+  );
+};
+
+export const Default = Template.bind({});
+
+export const TextConstrainedBy100pxContainer = (args) => {
+  return (
+    <div style={{ width: '100px'}}>
+      <TextEllipsis {...args} tooltipContent={ 'asdasd '} expand={ true} rows={ 1 } >
+        { 'Hello Axel, here is a really, really long text!'}
+      </TextEllipsis>
+    </div>
+  )
+}
+

--- a/stories/TextEllipsis.stories.tsx
+++ b/stories/TextEllipsis.stories.tsx
@@ -35,7 +35,7 @@ export const EllipseAfterTwoRows = (args) => {
         rows={ 2 }
         {...args}
       >
-        { 'Really, really, really, really, really, long text that gets cut!' }
+        { 'Really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, long text that gets cut!' }
       </TextEllipsis>
     </div>
   )

--- a/stories/TextEllipsis.stories.tsx
+++ b/stories/TextEllipsis.stories.tsx
@@ -4,27 +4,51 @@ import {
 } from '../src/components';
 
 export default {
-  title: 'Components/Ellipsed Text',
+  title: 'Components/Text Ellipsis',
   component: TextEllipsis,
 };
 
 const Template = (args) => {
   return (
     <div>
-      <TextEllipsis tooltipContent={ 'asdasd '} expand={ true} rows={ 1 } {...args}>
-        { 'Hello Axel, here is a really, really long text!'}
-      </TextEllipsis>
+      <h4>
+        1 row ellipse - tooltip on hover
+      </h4>
+      <div style={{ background: 'grey', margin: '16px 0px', padding: '16px', width: '350px'}}>
+        <TextEllipsis
+          rows={ 1 }
+          {...args}
+        >
+          { 'Really, really, really, really, really, really, long text that gets cut!' }
+        </TextEllipsis>
+      </div>
     </div>
   );
 };
 
 export const Default = Template.bind({});
 
-export const TextConstrainedBy100pxContainer = (args) => {
+export const EllipseAfterTwoRows = (args) => {
   return (
-    <div style={{ width: '100px'}}>
-      <TextEllipsis {...args} tooltipContent={ 'asdasd '} expand={ true} rows={ 1 } >
-        { 'Hello Axel, here is a really, really long text!'}
+    <div style={{ background: 'grey', margin: '16px 0px', padding: '16px', width: '350px'}}>
+      <TextEllipsis
+        rows={ 2 }
+        {...args}
+      >
+        { 'Really, really, really, really, really, long text that gets cut!' }
+      </TextEllipsis>
+    </div>
+  )
+}
+
+export const TextNotConstrainedByContainer = (args) => {
+  return (
+    <div style={{ background: 'grey', margin: '16px 0px', padding: '16px', width: '350px'}}>
+      <TextEllipsis
+        rows={ 1 }
+        {...args}
+      >
+        { 'Really, really, really long text that gets cut!' }
       </TextEllipsis>
     </div>
   )

--- a/stories/TextEllipsis.stories.tsx
+++ b/stories/TextEllipsis.stories.tsx
@@ -6,6 +6,19 @@ import {
 export default {
   title: 'Components/Text Ellipsis',
   component: TextEllipsis,
+  argTypes: {
+    tooltipPlacement: {
+      control: {
+        type: 'inline-radio',
+        options: ['top', 'right', 'bottom', 'left'],
+      },
+    },
+    rows: {
+      control: {
+        type: 'number'
+      }
+    },
+  },
 };
 
 const Template = (args) => {
@@ -27,6 +40,11 @@ const Template = (args) => {
 };
 
 export const Default = Template.bind({});
+
+Default.args = {
+  children: 'Really, really, really, really, really, really, long text that gets cut!',
+  rows: 1,
+};
 
 export const EllipseAfterTwoRows = (args) => {
   return (

--- a/stories/Typography.stories.tsx
+++ b/stories/Typography.stories.tsx
@@ -29,6 +29,6 @@ export const TypographyUtils: React.FC = () => (
 );
 
 export default {
-  title: 'Utils/Typrography',
+  title: 'Utils/Typography',
   component: Typography,
 };

--- a/stories/Typography.stories.tsx
+++ b/stories/Typography.stories.tsx
@@ -17,14 +17,14 @@ const text = 'Research and development refer to activities in connection with co
 export const TypographyUtils: React.FC = () => (
   <div>
     <h1>Typography</h1>
-    <Typography className="tk-mb-2h tk-text-ellipsis tk-text-ellipsis__single-row" type="h1">H1. {text}</Typography>
-    <Typography className="tk-mb-2h tk-text-ellipsis tk-text-ellipsis__single-row" type="h2">H2. {text}</Typography>
-    <Typography className="tk-mb-2h tk-text-ellipsis tk-text-ellipsis__single-row" type="h3">H3. {text}</Typography>
-    <Typography className="tk-mb-2h tk-text-ellipsis tk-text-ellipsis__single-row" type="h4">H4. {text}</Typography>
-    <Typography className="tk-mb-2h tk-text-ellipsis tk-text-ellipsis__single-row">Body. {text}</Typography>
-    <Typography className="tk-mb-2h tk-text-ellipsis tk-text-ellipsis__single-row" type="small">Small. {text}</Typography>
-    <Typography className="tk-mb-2h tk-text-ellipsis tk-text-ellipsis__single-row" variant="bold">Bold. {text}</Typography>
-    <Typography className="tk-mb-2h tk-text-ellipsis tk-text-ellipsis__single-row" variant="italic">Italic. {text}</Typography>
+    <Typography className="tk-mb-2h tk-text-ellipsis" type="h1">H1. {text}</Typography>
+    <Typography className="tk-mb-2h tk-text-ellipsis" type="h2">H2. {text}</Typography>
+    <Typography className="tk-mb-2h tk-text-ellipsis" type="h3">H3. {text}</Typography>
+    <Typography className="tk-mb-2h tk-text-ellipsis" type="h4">H4. {text}</Typography>
+    <Typography className="tk-mb-2h tk-text-ellipsis">Body. {text}</Typography>
+    <Typography className="tk-mb-2h tk-text-ellipsis" type="small">Small. {text}</Typography>
+    <Typography className="tk-mb-2h tk-text-ellipsis" variant="bold">Bold. {text}</Typography>
+    <Typography className="tk-mb-2h tk-text-ellipsis" variant="italic">Italic. {text}</Typography>
   </div>
 );
 

--- a/stories/Typography.stories.tsx
+++ b/stories/Typography.stories.tsx
@@ -17,14 +17,14 @@ const text = 'Research and development refer to activities in connection with co
 export const TypographyUtils: React.FC = () => (
   <div>
     <h1>Typography</h1>
-    <Typography className="tk-mb-2h tk-text-ellipsis" type="h1">H1. {text}</Typography>
-    <Typography className="tk-mb-2h tk-text-ellipsis" type="h2">H2. {text}</Typography>
-    <Typography className="tk-mb-2h tk-text-ellipsis" type="h3">H3. {text}</Typography>
-    <Typography className="tk-mb-2h tk-text-ellipsis" type="h4">H4. {text}</Typography>
-    <Typography className="tk-mb-2h tk-text-ellipsis">Body. {text}</Typography>
-    <Typography className="tk-mb-2h tk-text-ellipsis" type="small">Small. {text}</Typography>
-    <Typography className="tk-mb-2h tk-text-ellipsis" variant="bold">Bold. {text}</Typography>
-    <Typography className="tk-mb-2h tk-text-ellipsis" variant="italic">Italic. {text}</Typography>
+    <Typography className="tk-mb-2h tk-text-ellipsis tk-text-ellipsis__single-row" type="h1">H1. {text}</Typography>
+    <Typography className="tk-mb-2h tk-text-ellipsis tk-text-ellipsis__single-row" type="h2">H2. {text}</Typography>
+    <Typography className="tk-mb-2h tk-text-ellipsis tk-text-ellipsis__single-row" type="h3">H3. {text}</Typography>
+    <Typography className="tk-mb-2h tk-text-ellipsis tk-text-ellipsis__single-row" type="h4">H4. {text}</Typography>
+    <Typography className="tk-mb-2h tk-text-ellipsis tk-text-ellipsis__single-row">Body. {text}</Typography>
+    <Typography className="tk-mb-2h tk-text-ellipsis tk-text-ellipsis__single-row" type="small">Small. {text}</Typography>
+    <Typography className="tk-mb-2h tk-text-ellipsis tk-text-ellipsis__single-row" variant="bold">Bold. {text}</Typography>
+    <Typography className="tk-mb-2h tk-text-ellipsis tk-text-ellipsis__single-row" variant="italic">Italic. {text}</Typography>
   </div>
 );
 


### PR DESCRIPTION
https://perzoinc.atlassian.net/browse/APP-3334

- Added TextEllipsis component
-- Will show Tooltip when text is ellipsed
-- You can set number of rows before ellipse

<img width="472" alt="Screenshot 2021-07-26 at 16 13 40" src="https://user-images.githubusercontent.com/60875212/127005284-c78ff66b-8234-4a4b-983a-7086a9864379.png">

Two row ellipse
<img width="1009" alt="Screenshot 2021-07-26 at 21 33 47" src="https://user-images.githubusercontent.com/60875212/127047896-b27ff4e3-290a-4253-9a11-5557bfb08d67.png">

## Todo
https://github.com/SymphonyPlatformSolutions/symphony-bdk-ui-toolkit-styles/pull/120 - Needs to merge first.

## Discussion
Should tooltip on ellipsed and on hover be optional? Can add another flag for it.