### PR TITLE
Added a <StylesInjection> HOC that takes care of injecting styles from different styling libraries to the correct document

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -1,0 +1,15 @@
+# 🧮 Advanced Usage
+
+## 🚏 Using UIToolkit outside the main document
+Some UIToolkit components use styling libraries like `@emotion` and `styled-components` that inject styling into the `<head>` of the main document. If you use these components in a document outside the main one, the styling will only be applied to the main document. You need to use the `<StylesInjection>` component in your root and add an injection point. For example:
+
+```
+import { StylesInjection } from '@symphony-ui/uitoolkit-components';
+
+return (
+    <StylesInjection id="unique_id" injectionPoint={ externalDocument.head }>
+        <Dropdown/>
+        <Tooltip/>
+    </StylesInjection>
+);
+```

--- a/spec/core/hoc/StylesInjection.spec.tsx
+++ b/spec/core/hoc/StylesInjection.spec.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { StylesInjection } from '../../../src/core/hoc/StylesInjection'
+
+describe('StylesInjection', () => {
+  
+  it('should render', () => {
+    render(<StylesInjection id="test-id" injectionPoint={document.head}>
+      <p>Hello!</p>
+    </StylesInjection>)
+  })
+
+})

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -25,6 +25,7 @@ import Validation from './validation';
 import VirtualizedList from './virtualized-list';
 
 /* Let's move into exporting everything with interfaces */
+export * from '../core/hoc/index';
 export * from './avatar';
 export * from './badge';
 export * from './banner';

--- a/src/core/hoc/StylesInjection.tsx
+++ b/src/core/hoc/StylesInjection.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { StyleSheetManager } from 'styled-components';
+import createCache from '@emotion/cache';
+import { CacheProvider } from '@emotion/react';
+
+interface Props extends React.HTMLProps<HTMLDivElement> {
+    id: string;
+    injectionPoint?: HTMLElement | undefined;
+}
+
+export const StylesInjection = (props: Props) => {
+
+  const emotionCache = createCache({
+    key: props.id,
+    container: props.injectionPoint
+  });
+
+  return (
+    <StyleSheetManager target={ props.injectionPoint }>
+      <CacheProvider value={ emotionCache } >
+        { props.children }
+      </CacheProvider>
+    </StyleSheetManager>
+  )
+}

--- a/src/core/hoc/index.ts
+++ b/src/core/hoc/index.ts
@@ -1,0 +1,1 @@
+export * from './StylesInjection';


### PR DESCRIPTION
Created an <UIToolkit> component that takes care of injecting styles from different styling libraries to the correct context. UIToolkit has `styled-components` and  `@emotion` right now that need help injecting their styles to the correct document. Instead of users of this library needing these they need only one import, `<UIToolkit>` with the injectionPoint props that will take of the injection to the correct libraries.