### PR TITLE
fix bug 280: classname of tootltip is wrong

### DIFF
--- a/spec/components/tooltip/Tooltip.spec.tsx
+++ b/spec/components/tooltip/Tooltip.spec.tsx
@@ -24,6 +24,9 @@ describe('Tooltip', () => {
   let placement: 'top' | 'bottom' | 'left' | 'right';
   let visible: boolean;
 
+  const testToolTipId = 'testToolTipId';
+  const testTooltipClassname = 'testTooltipClassname';
+
   beforeEach(() => {
     closeLabel = 'Close';
     description = 'Message appears';
@@ -246,6 +249,40 @@ describe('Tooltip', () => {
     });
     userEvent.unhover(screen.getByRole('button', { name: /text hover/i }));
     await waitForElementToBeRemoved(() => screen.getByText(/appears$/i));
+  }
+  );
+
+  it('should have right classname pass by props.classname', async () => {
+    displayTrigger = 'hover';
+    
+    render(
+      <Tooltip
+        closeLabel={closeLabel}
+        description={description}
+        displayTrigger={displayTrigger}
+        id={id}
+        onHintClose={onHintClose}
+        placement="top"
+        hoverDelay={800}
+        data-testid={testToolTipId}
+        className={testTooltipClassname}
+      >
+        <button
+          id="button"
+          onMouseEnter={() => changeElementText('#button', 'text hover')}
+          onMouseLeave={() => changeElementText('#button', 'text unhover')}
+        >
+          Tooltip toggles when I am clicked
+        </button>
+      </Tooltip>
+    );
+
+    userEvent.hover(
+      screen.getByRole('button', { name: /tooltip toggles when I am clicked/i })
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId(testToolTipId).classList.contains(testTooltipClassname)).toBe(true);
+    });
   }
   );
 });

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -170,7 +170,7 @@ const Tooltip: React.FC<TooltipProps> = ({
             ref={setPopperElement}
             className={classnames(
               type === 'tooltip' ? 'tk-tooltip' : 'tk-hint',
-              { className }
+              className
             )}
             style={styles.popper}
             {...attributes.popper}


### PR DESCRIPTION
## Description
Problem is object in classnames: { className } => always have class className in your html, it is not name of class which you pass from props(className)

It should be [className] instead of {className}
(https://github.com/JedWatson/classnames)

## Issue

[Issue](https://github.com/SymphonyPlatformSolutions/symphony-bdk-ui-toolkit-components/issues/280)

