### PR TITLE
Allow keyboard navigation in dropdowm menu

### DIFF
--- a/spec/components/dropdown-menu/DropdownMenu.spec.tsx
+++ b/spec/components/dropdown-menu/DropdownMenu.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {mount} from 'enzyme';
 import {DropdownMenu, DropdownMenuDivider, DropdownMenuItem} from '../../../src/components';
 import {fireEvent, getByText, render, screen} from '@testing-library/react';
+import userEvent, {specialChars} from '@testing-library/user-event';
 
 describe('DropdownMenu', () => {
   it('should render with the correct classes without crash', () => {
@@ -50,5 +51,36 @@ describe('DropdownMenu', () => {
     fireEvent.click(document.body);
     fireEvent.keyUp(document.body, {key: 'Escape', code: 'Escape'});
     expect(close).toHaveBeenCalled();
+  });
+
+  it('should move focus between options by pressing arrow down/up on the current option', () => {
+    render(
+      <DropdownMenu show={true}>
+        <DropdownMenuItem data-testid={'option_1'}>Option 1</DropdownMenuItem>
+        <DropdownMenuItem data-testid={'option_2'}>Option 2</DropdownMenuItem>
+      </DropdownMenu>
+    )
+
+    userEvent.type(screen.getByTestId('option_1'), specialChars.arrowDown);
+    expect(screen.getByTestId('option_2')).toHaveFocus();
+
+    userEvent.type(screen.getByTestId('option_2'), specialChars.arrowUp);
+    expect(screen.getByTestId('option_1')).toHaveFocus();
+
+    // reaches the end
+    userEvent.type(screen.getByTestId('option_1'), specialChars.arrowUp);
+    expect(screen.getByTestId('option_2')).toHaveFocus();
+  })
+
+  it('should call onClick when pressing enter on an option', () => {
+    const onClick = jest.fn();
+    render(
+      <DropdownMenu show={true}>
+        <DropdownMenuItem data-testid={'option_1'} onClick={onClick}>Option 1</DropdownMenuItem>
+      </DropdownMenu>
+    )
+
+    userEvent.type(screen.getByTestId('option_1'), specialChars.enter);
+    expect(onClick).toHaveBeenCalled();
   })
 })

--- a/src/components/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/dropdown-menu/DropdownMenu.tsx
@@ -13,19 +13,47 @@ interface DropdownMenuProps extends React.HTMLProps<HTMLDivElement> {
 interface DropdownMenuItemProps extends React.HTMLProps<HTMLDivElement> {
   children?: React.ReactNode;
   className?: string;
-  onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+  /** To select a certain option in the menu without having to use document.querySelector */
+  forwardRef?: React.RefObject<HTMLDivElement>;
+  onClick?: (event: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => void;
 }
 
 export const DropdownMenuDivider: React.FC = () => <div className="tk-dropdown-menu-divider"></div>
 
-export const DropdownMenuItem: React.FC<DropdownMenuItemProps> = ({children, className, onClick, ...rest}: DropdownMenuItemProps) => {
+export const DropdownMenuItem: React.FC<DropdownMenuItemProps> = ({children, className, onClick, forwardRef, ...rest}: DropdownMenuItemProps) => {
   const classes = classNames(
     'tk-dropdown-menu__item',
     className,
   )
 
+  const focusNextOption = (current: HTMLDivElement, direction: number) => {
+    const options = (Array.from(current.parentElement.getElementsByClassName('tk-dropdown-menu__item'))) as HTMLDivElement[];
+    let currentOptionPosition = options.indexOf(current);
+    currentOptionPosition = currentOptionPosition > -1 ? currentOptionPosition : 0;
+    const nextElementPosition = (currentOptionPosition + options.length + direction) % options.length;
+
+    options[nextElementPosition].focus();
+  }
+
+  const onKeyDownHandler = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    switch (e.key) {
+    case Keys.ARROW_DOWN :
+      e.stopPropagation();
+      focusNextOption(e.currentTarget, 1);
+      break;
+    case Keys.ARROW_UP:
+      e.stopPropagation();
+      focusNextOption(e.currentTarget, -1);
+      break;
+    case Keys.ENTER:
+      e.stopPropagation();
+      onClick(e);
+      break;
+    }
+  }
+
   return (
-    <div {...rest} className={classes} onClick={onClick}>
+    <div {...rest} className={classes} onClick={onClick} ref={forwardRef} onKeyDown={onKeyDownHandler} tabIndex={-1}>
       {children}
     </div>
   )
@@ -66,5 +94,5 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = ({children, className, 
       {children}
     </div>
   )
-}
+};
 


### PR DESCRIPTION
Allow user to navigate between menu options using keyboard and activate a certain option by pressing enter. 


https://user-images.githubusercontent.com/32852556/133571267-c9adbb27-d434-48c3-9c7e-079b9e587177.mov

