### PR TITLE
APP-4518 Temporarily use shortId instead of nanoid because nanoid is not transpiled for IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "emoji-js": "^3.5.0",
     "github-markdown-css": "^4.0.0",
     "lodash": "^4.17.21",
-    "nanoid": "^3.1.25",
     "prop-types": "^15.7.2",
     "react-cool-onclickoutside": "^1.5.8",
     "react-popper": "^2.2.3",
@@ -46,6 +45,7 @@
     "react-select": "^4.3.1",
     "react-transition-group": "^4.4.1",
     "react-virtualized": "^9.22.2",
+    "shortid": "^2.2.16",
     "styled-components": "^5.1.1"
   },
   "devDependencies": {

--- a/src/components/input/InputDecorator.tsx
+++ b/src/components/input/InputDecorator.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { useMemo } from 'react';
 import classnames from 'classnames';
-import { nanoid } from 'nanoid'
+import shortid from 'shortid';
 import LabelTooltipDecorator from '../label-tooltip-decorator/LabelTooltipDecorator';
 import {
   LabelTooltipDecoratorProps,
@@ -65,10 +65,10 @@ const InputDecorator: React.FC<InputDecoratorProps> = ({
 
   // Generate unique ID if not provided
   const inputId = useMemo(() => {
-    return child?.props?.id || `tk-input-${nanoid()}`;
+    return child?.props?.id || `tk-input-${shortid.generate()}`;
   }, [child]);
 
-  const tooltipId = useMemo(() => `tk-hint-${nanoid()}`, []);
+  const tooltipId = useMemo(() => `tk-hint-${shortid.generate()}`, []);
 
   const disabled = useMemo(() => {
     return child?.props?.disabled;

--- a/src/components/input/TextComponent.tsx
+++ b/src/components/input/TextComponent.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { useEffect, useMemo, useState } from 'react';
 import classNames from 'classnames';
-import { nanoid } from 'nanoid';
+import shortid from 'shortid';
 
 import { HasValidationProps } from '../validation/interfaces';
 import { HasTooltipProps } from '../tooltip/interfaces';
@@ -119,10 +119,10 @@ const TextComponent: React.FC<
 
     // Generate unique ID if not provided
     const inputId = useMemo(() => {
-      return id || `tk-input-${nanoid()}`;
+      return id || `tk-input-${shortid.generate()}`;
     }, [id]);
 
-    const tooltipId = useMemo(() => `tk-hint-${nanoid()}`, []);
+    const tooltipId = useMemo(() => `tk-hint-${shortid.generate()}`, []);
 
     const handleViewText = (event) => {
       if (disabled) return;

--- a/src/components/selection/SelectionInput.tsx
+++ b/src/components/selection/SelectionInput.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { nanoid } from 'nanoid';
+import shortid from 'shortid';
 import SelectionTypes, { SelectionInputTypes } from './SelectionTypes';
 import SelectionStatus, { getCheckedValue } from './SelectionStatus';
 import LabelPlacements from './LabelPlacements';
@@ -48,7 +48,7 @@ const SelectionInput: React.FC<SelectionInputPropsWithType> = ({
 }) => {
   // Generate unique ID if not provided
   const memoizedId = useMemo(() => {
-    return id || `${type}-${nanoid()}`;
+    return id || `${type}-${shortid.generate()}`;
   }, [id]);
 
   // Default labelPlacement on right if not provided

--- a/src/core/hoc/StylesInjection.tsx
+++ b/src/core/hoc/StylesInjection.tsx
@@ -2,26 +2,26 @@ import * as React from 'react';
 import { StyleSheetManager } from 'styled-components';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
-import { customAlphabet } from 'nanoid';
+import shortid from 'shortid';
 
 interface Props extends Pick<React.HTMLProps<HTMLDivElement>, 'children'> {
-    injectionPoint?: HTMLElement | undefined;
+  injectionPoint?: HTMLElement | undefined;
 }
 
 export const StylesInjection = (props: Props) => {
 
   // @emotion/cache only accept alpha characters
-  const generateUniqueAlphaCharacter = customAlphabet('abcdefghijklmnopqrstuvwxyz', 16);
+  shortid.characters('abcdefghijklmnopqrstuvwxyz');
 
   const emotionCache = createCache({
-    key: generateUniqueAlphaCharacter(),
+    key: shortid.generate(),
     container: props.injectionPoint
   });
 
   return (
-    <StyleSheetManager target={ props.injectionPoint }>
-      <CacheProvider value={ emotionCache } >
-        { props.children }
+    <StyleSheetManager target={props.injectionPoint}>
+      <CacheProvider value={emotionCache} >
+        {props.children}
       </CacheProvider>
     </StyleSheetManager>
   )

--- a/src/core/hoc/StylesInjection.tsx
+++ b/src/core/hoc/StylesInjection.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { StyleSheetManager } from 'styled-components';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
-import shortid from 'shortid';
 
 interface Props extends Pick<React.HTMLProps<HTMLDivElement>, 'children'> {
   injectionPoint?: HTMLElement | undefined;
@@ -11,10 +10,12 @@ interface Props extends Pick<React.HTMLProps<HTMLDivElement>, 'children'> {
 export const StylesInjection = (props: Props) => {
 
   // @emotion/cache only accept alpha characters
-  shortid.characters('abcdefghijklmnopqrstuvwxyz');
+  // Don't use shortid because it doesn't support less than 64 unique characters (See https://github.com/dylang/shortid#shortidcharactersstring)
+  // Later we will use nanoid
+  const uniqueAlphaCharacterId = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 10);
 
   const emotionCache = createCache({
-    key: shortid.generate(),
+    key: uniqueAlphaCharacterId,
     container: props.injectionPoint
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9250,7 +9250,12 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
-nanoid@^3.1.22, nanoid@^3.1.25:
+nanoid@^2.1.0:
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
+  integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
+
+nanoid@^3.1.22:
   version "3.1.25"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.25.tgz#09ca32747c0e543f0e1814b7d3793477f9c8e152"
   integrity sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==
@@ -11522,6 +11527,13 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
+shortid@^2.2.16:
+  version "2.2.16"
+  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.16.tgz#b742b8f0cb96406fd391c76bfc18a67a57fe5608"
+  integrity sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==
+  dependencies:
+    nanoid "^2.1.0"
 
 side-channel@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
**Jira ticket**
https://perzoinc.atlassian.net/browse/APP-4518

**Changes**
Temporarily use shortId instead of nanoid because nanoid is not transpiled for IE11

See comment in issue: https://github.com/ai/nanoid/issues/210
And nanoid release note: https://github.com/ai/nanoid/releases/tag/3.0.0.