### PR TITLE
RTC-10961 - Improving TextEllipsis component

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -13,3 +13,25 @@ return (
     </StylesInjection>
 );
 ```
+
+## 🔗 Linking UIToolkit
+If you are linking UIToolkit in another repository there is a risk there will be two instances of `react` and `react-dom` running which can cause [Invalid Hook Call](https://reactjs.org/warnings/invalid-hook-.call-warning.html).
+
+Try linking YOUR_PROJECT's `react` and `react-dom` modules to UIToolkit.
+
+```
+cd YOUR_PROJECT
+cd node_modules/react
+yarn link
+cd ../react-dom
+yarn link
+
+cd symphony-bdk-ui-toolkit-components
+yarn link
+yarn install
+yarn link react
+yarn link react-dom
+
+cd YOUR_PROJECT
+yarn link "@symphony-ui/uitoolkit-components"
+```

--- a/src/components/text-ellipsis/TextEllipsis.tsx
+++ b/src/components/text-ellipsis/TextEllipsis.tsx
@@ -12,7 +12,7 @@ interface TextEllipsisProps extends Omit<React.HTMLProps<HTMLSpanElement>, 'type
     /** Wheather a tooltip should be shown on hover when the text is ellipsed */
     tooltipOnEllipsis?: boolean;
 
-    tooltipProps?: TooltipProps;
+    tooltipProps?: Partial<TooltipProps>;
 }
 
 export const TextEllipsis: React.FC<TextEllipsisProps> = ({
@@ -39,7 +39,7 @@ export const TextEllipsis: React.FC<TextEllipsisProps> = ({
 
   const getTextEllipsisHTML = () => {
     return (<span
-      className={ classnames(className, 'tk-text-ellipsis') }
+      className={ classnames(className, 'tk-text-ellipsis', { 'tk-text-ellipsis__multiple-rows': rows > 1 }) }
       style={{ WebkitLineClamp: rows, ...style}}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
@@ -48,15 +48,15 @@ export const TextEllipsis: React.FC<TextEllipsisProps> = ({
       { children }
     </span>)
   }
-
+  
   if(tooltipOnEllipsis) {
     return(
       <Tooltip
-        description={ children as JSX.Element }
-        placement={ 'top' }
-        type="tooltip"
-        visible={ showTooltip }
-        { ...tooltipProps }
+        {...tooltipProps}
+        description={ tooltipProps?.description ?? children as JSX.Element }
+        placement={ tooltipProps?.placement ?? 'top' }
+        type={ tooltipProps?.type ?? 'tooltip' }
+        visible={ tooltipProps?.visible ?? showTooltip }
       >
         {getTextEllipsisHTML()}
       </Tooltip>

--- a/stories/TextEllipsis.stories.tsx
+++ b/stories/TextEllipsis.stories.tsx
@@ -65,6 +65,33 @@ export const EllipseAfterTwoRows = (args) => {
   )
 }
 
+export const EllipseAContinuousString = (args) => {
+  return (
+    <div style={{ background: 'grey', margin: '16px 0px', padding: '16px', width: '350px'}}>
+      <TextEllipsis
+        {...args}
+      >
+        { 'A really longcontinuousstringthatseeminglyneverends' }
+      </TextEllipsis>
+    </div>
+  )
+}
+
+export const EllipseAContinuousStringTwoRows = (args) => {
+  return (
+    <div style={{ background: 'grey', margin: '16px 0px', padding: '16px', width: '350px'}}>
+      <TextEllipsis
+        rows={ 2 }
+        {...args}
+      >
+        { 'A really, really, long string that wraps two rows and ends with a longcontinuousstringthatseeminglyneverends' }
+      </TextEllipsis>
+    </div>
+  )
+}
+
+EllipseAContinuousStringTwoRows.decorators = [addExplanation('When the long continuous string is not the first word on a multi-line ellipsis it does not work')]
+
 export const TooltipNotAffectingStyling = (args) => {
   return (
     <div style={{ background: 'grey', display: 'flex', margin: '16px 0px', padding: '16px', width: '350px'}}>


### PR DESCRIPTION
https://perzoinc.atlassian.net/browse/RTC-10961

## Changes
- Applying the `__multiple-rows` property to text-ellipsis if rows are > 1
- Adding documentation regarding linking `react` and `react-dom`
- tooltipProps on TextEllipsis should be a Partial

<img width="1139" alt="Screenshot 2021-09-27 at 10 32 46" src="https://user-images.githubusercontent.com/60875212/134873511-070acba9-4f63-4054-9003-99a175254d1b.png">

## UIToolkit styles PR
https://github.com/SymphonyPlatformSolutions/symphony-bdk-ui-toolkit-styles/pull/139