### PR TITLE
APP-4567 / APP-4568: `SelectionInput` update for the SDS alignment

### DIFF
--- a/spec/components/selection/SelectionInput.spec.tsx
+++ b/spec/components/selection/SelectionInput.spec.tsx
@@ -13,23 +13,59 @@ describe('SelectionInput Component', () => {
     });
 
     it('render a Checkbox with default props and initial value and test if a input html tag is used', () => {
+      const props = {
+        type: SelectionTypes.CHECKBOX,
+        name: 'SelectionInput-test-name',
+        value: 'SelectionInput-test-value',
+      }
+
       const wrapper = shallow(
-        <SelectionInput
-          type={SelectionTypes.CHECKBOX}
-          name="SelectionInput-test-name"
-          value="SelectionInput-test-value"
-        />
+        <SelectionInput {...props} />
       );
+
       expect(wrapper.length).toEqual(1);
       expect(wrapper.find('.tk-checkbox').length).toBe(1);
       expect(wrapper.find('input').length).toBe(1);
-      expect(wrapper.find('input').prop('name')).toEqual(
-        'SelectionInput-test-name'
-      );
-      expect(wrapper.find('input').prop('value')).toEqual(
-        'SelectionInput-test-value'
-      );
+      expect(wrapper.find('input').prop('name')).toEqual(props.name);
+      expect(wrapper.find('input').prop('value')).toEqual(props.value);
     });
+
+    it('render a Radio with default props and initial value', () => {
+      const props = {
+        type: SelectionTypes.RADIO,
+        name: 'SelectionInput-test-name',
+        value: 'SelectionInput-test-value',
+      }
+
+      const wrapper = shallow(
+        <SelectionInput {...props} />
+      );
+
+      expect(wrapper.length).toEqual(1);
+      expect(wrapper.find('.tk-radio').length).toBe(1);
+      expect(wrapper.find('input').length).toBe(1);
+      expect(wrapper.find('input').prop('name')).toEqual(props.name);
+      expect(wrapper.find('input').prop('value')).toEqual(props.value);
+    });
+
+    it('render a Switch with default props and initial value', () => {
+      const props = {
+        type: SelectionTypes.SWITCH,
+        name: 'SelectionInput-test-name',
+        value: 'SelectionInput-test-value',
+      }
+
+      const wrapper = shallow(
+        <SelectionInput {...props} />
+      );
+
+      expect(wrapper.length).toEqual(1);
+      expect(wrapper.find('.tk-switch').length).toBe(1);
+      expect(wrapper.find('input').length).toBe(1);
+      expect(wrapper.find('input').prop('name')).toEqual(props.name);
+      expect(wrapper.find('input').prop('value')).toEqual(props.value);
+    });
+
     it('extra props are forwarded to the input element', () => {
       const ariaLabel = 'field';
       const wrapper = shallow(
@@ -42,6 +78,20 @@ describe('SelectionInput Component', () => {
       );
       expect(wrapper.length).toEqual(1);
       expect(wrapper.find('input').prop('aria-label')).toEqual(ariaLabel);
+    });
+
+    it('renders a disabled input if disabled prop is true', () => {
+      const wrapper = shallow(
+        <SelectionInput
+          type={SelectionTypes.CHECKBOX}
+          name="SelectionInput-test-name2"
+          value="SelectionInput-test-value"
+          disabled
+        />
+      );
+
+      expect(wrapper.find('.tk-checkbox--disabled')).toBeDefined();
+      expect(wrapper.find('input').prop('disabled')).toEqual(true);
     });
 
     it('with click handler', () => {
@@ -63,6 +113,7 @@ describe('SelectionInput Component', () => {
       wrapper.find('input').simulate('change');
       expect(changeCallback).toBeCalled();
     });
+
     it('should select the checkbox when the "Space" touch is pressed', async () => {
       // Set-up event listener mock
       const map = {};
@@ -98,6 +149,7 @@ describe('SelectionInput Component', () => {
       wrapper.update();
       expect(clickCallback).toBeCalled();
     });
+
     it('should add "focus-visible" CSS class when "Tab" touch is pressed', async () => {
       // Set-up event listener mock
       const map = {};
@@ -141,6 +193,7 @@ describe('SelectionInput Component', () => {
       expect(wrapper.find('.tk-checkbox--focus-visible').length).toBe(1);
       expect(wrapper.find('.tk-checkbox--focused').length).toBe(1);
     });
+
     it('should remove the "focused" CSS class on blur', async () => {
       // Set-up event listener mock
       const map = {};

--- a/src/components/selection/SelectionInput.tsx
+++ b/src/components/selection/SelectionInput.tsx
@@ -155,6 +155,7 @@ const SelectionInput: React.FC<SelectionInputPropsWithType> = ({
           [`${tkClassName}--focused`]: isFocused,
           [`${tkClassName}--focus-visible`]: isFocusVisible,
           [`${tkClassName}--mixed`]: status === SelectionStatus.MIXED,
+          [`${tkClassName}--disabled`]: disabled,
         }
       )}
       tab-index="-1"

--- a/stories/Checkbox.stories.tsx
+++ b/stories/Checkbox.stories.tsx
@@ -71,6 +71,33 @@ export const Checkboxes = () => {
         />
       </div>
       <div>
+        <h2>Error Checkbox</h2>
+        <p>In the following examples the checkboxes are wrapped around a Validation component that is in error</p>
+        <span className="tk-validation--error">
+          <Checkbox
+            label="Checkbox 'checked'"
+            name="active-checkbox"
+            value="active-checkbox-1"
+            status={SelectionStatus.CHECKED}
+          />
+        </span>
+        <span className="tk-validation--error">
+          <Checkbox
+            label="Checkbox 'mixed'"
+            name="active-checkbox"
+            value="active-checkbox-2"
+            status={SelectionStatus.MIXED}
+          />
+        </span>
+        <span className="tk-validation--error">
+          <Checkbox
+            label="Checkbox by default"
+            name="active-checkbox"
+            value="active-checkbox-3"
+          />
+        </span>
+      </div>
+      <div>
         <h2>Label placements</h2>
         <p>
           The label can be positioned at the{' '}


### PR DESCRIPTION
**APP-4567 / APP-4568: `SelectionInput` update for the SDS alignment**

- adds the `tk-{type}--disabled` class to the parent div --> allows to change the label color from CSS when the input is disabled (because from the `label` location, we were not able to access the input's `disabled` attribute)
- updates `SelectionInput` tests

--------

Related style PR: https://github.com/SymphonyPlatformSolutions/symphony-bdk-ui-toolkit-styles/pull/152
Related tickets:
- https://perzoinc.atlassian.net/browse/APP-4567
- https://perzoinc.atlassian.net/browse/APP-4568

-------

https://user-images.githubusercontent.com/66251236/137888184-5f94ceb0-6eb1-426e-af6e-9751f916c2cc.mov
