### PR TITLE
APP-4649 Remove the breaking change on the Button component

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -7,7 +7,7 @@ const prefix = 'tk-button';
 export type ButtonProps = {
   /** If true, add an Icon component as children */
   iconButton?: boolean;
-   /** Content of the button*/
+  /** Content of the button*/
   children?: React.ReactNode;
   /** Optional CSS class name */
   className?: string;
@@ -16,8 +16,8 @@ export type ButtonProps = {
   loading?: boolean;
   type?: 'button' | 'reset' | 'submit';
   onClick?: (event: React.MouseEvent<HTMLElement>) => void;
-   /** The variant to use*/
-  variant?: 'primary' | 'secondary' | 'tertiary' | 'destructive' | 'primary-destructive' | 'secondary-destructive'|'tertiary-destructive' |'tertiary-accent';
+  /** The variant to use*/
+  variant?: 'primary' | 'secondary' | 'tertiary' | 'destructive' | 'primary-destructive' | 'secondary-destructive' | 'tertiary-destructive' | 'tertiary-accent';
   size?: 'large' | 'small' | 'medium';
   iconRight?: React.ReactNode;
   iconLeft?: React.ReactNode;
@@ -45,7 +45,7 @@ export const Button: React.FC<ButtonProps> = ({
     `${prefix}--${size}`
   );
 
-  if(variant === 'destructive') {
+  if (variant === 'destructive') {
     console.warn('The button variant: \'destructive\' will be deprecated.\n Please use: \'primary-destructive\' instead')
   }
 
@@ -58,7 +58,7 @@ export const Button: React.FC<ButtonProps> = ({
       {...rest}
     >
       {loading && <i className="animate-spin tk-icon-loading" />}
-      <span className={classNames({ [`${prefix}--icon-right`] : iconRight , [`${prefix}--icon-left`]: iconLeft })}
+      <span className={classNames({ [`${prefix}--icon-right`]: iconRight, [`${prefix}--icon-left`]: iconLeft })}
         style={{ visibility: loading ? 'hidden' : null }}>
         {iconLeft}{children}{iconRight}
       </span>
@@ -83,9 +83,9 @@ Button.propTypes = {
   disabled: PropTypes.bool,
   loading: PropTypes.bool,
   type: PropTypes.oneOf(['button', 'reset', 'submit']),
-  variant: PropTypes.oneOf(['primary' , 'secondary' , 'tertiary' , 'destructive' , 'primary-destructive' , 'secondary-destructive','tertiary-destructive' ,'tertiary-accent']),
+  variant: PropTypes.oneOf(['primary', 'secondary', 'tertiary', 'destructive', 'primary-destructive', 'secondary-destructive', 'tertiary-destructive', 'tertiary-accent']),
   onClick: PropTypes.func,
-  size: PropTypes.oneOf(['small', 'large' , 'medium']),
+  size: PropTypes.oneOf(['small', 'large', 'medium']),
   iconLeft: PropTypes.node,
   iconRight: PropTypes.node,
 }

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -40,9 +40,8 @@ export const Button: React.FC<ButtonProps> = ({
     className,
     prefix,
     `${prefix}--${variant}`,
-    iconButton && `${prefix}--icon`,
-    `${loading ? 'loading' : ''}`,
-    `${prefix}--${size}`
+    `${prefix}--${size}`,
+    { [`${prefix}--icon`]: iconButton, 'loading': loading, [`${prefix}--icon-left`]: iconLeft, [`${prefix}--icon-right`]: iconRight },
   );
 
   if (variant === 'destructive') {
@@ -51,18 +50,17 @@ export const Button: React.FC<ButtonProps> = ({
 
   return (
     <button
+      aria-label={loading ? 'loading' : null}
       className={classes}
       disabled={loading || disabled}
+      style={{ color: loading ? 'transparent' : null }}
       /* eslint-disable react/button-has-type */
       type={type}
       {...rest}
     >
       {loading && <i className="animate-spin tk-icon-loading" />}
-      <span className={classNames({ [`${prefix}--icon-right`]: iconRight, [`${prefix}--icon-left`]: iconLeft })}
-        style={{ visibility: loading ? 'hidden' : null }}>
-        {iconLeft}{children}{iconRight}
-      </span>
-    </button>
+      {iconLeft}{children}{iconRight}
+    </button >
   );
 };
 

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -58,7 +58,7 @@ export const Button: React.FC<ButtonProps> = ({
       type={type}
       {...rest}
     >
-      {loading && <i className="animate-spin tk-icon-loading" />}
+      {loading && <i className="tk-button-icon--loading animate-spin tk-icon-loading" />}
       {iconLeft}{children}{iconRight}
     </button >
   );

--- a/stories/Button.stories.tsx
+++ b/stories/Button.stories.tsx
@@ -17,10 +17,10 @@ export const Variants: React.FC = () => (
     <h2>Primary</h2>
     <div style={{ display: 'flex', margin: 16 }}>
       <Button variant="primary" >Button</Button>
-      <Button variant="primary" iconLeft={<Icon iconName="lock"/>}>
+      <Button variant="primary" iconLeft={<Icon iconName="lock" />}>
         Icon left
       </Button>
-      <Button variant="primary" iconRight={<Icon iconName="lock"/>}>
+      <Button variant="primary" iconRight={<Icon iconName="lock" />}>
         Icon right
       </Button>
       <Button variant="primary" loading>
@@ -30,34 +30,34 @@ export const Variants: React.FC = () => (
         <Icon iconName="lock"></Icon>
       </Button>
       <Button variant="primary" disabled>
-      Disabled
+        Disabled
       </Button>
     </div>
- 
+
     <h3>destructive</h3>
     <div style={{ display: 'flex', margin: 16 }}>
       <Button variant="primary-destructive"> Button</Button>
-      <Button variant="primary-destructive" iconLeft={<Icon iconName="lock"/>}>
+      <Button variant="primary-destructive" iconLeft={<Icon iconName="lock" />}>
         Icon left
       </Button>
-      <Button variant="primary-destructive"  iconRight={<Icon iconName="lock"/>}>
+      <Button variant="primary-destructive" iconRight={<Icon iconName="lock" />}>
         Icon right
       </Button>
       <Button variant="primary-destructive" iconButton>
         <Icon iconName="lock"></Icon>
       </Button>
       <Button variant="primary-destructive" disabled>
-      Disabled
+        Disabled
       </Button>
     </div>
 
     <h2 className="tk-mt-5h">Secondary</h2>
     <div style={{ display: 'flex', margin: 16 }}>
       <Button variant="secondary">Button</Button>
-      <Button variant="secondary" iconLeft={<Icon iconName="lock"/>}>
+      <Button variant="secondary" iconLeft={<Icon iconName="lock" />}>
         Icon left
       </Button>
-      <Button variant="secondary" iconRight={<Icon iconName="lock"/>}>
+      <Button variant="secondary" iconRight={<Icon iconName="lock" />}>
         Icon right
       </Button>
       <Button variant="secondary" loading>
@@ -67,7 +67,7 @@ export const Variants: React.FC = () => (
         <Icon iconName="lock"></Icon>
       </Button>
       <Button variant="secondary" disabled>
-      Disabled
+        Disabled
       </Button>
 
 
@@ -75,27 +75,27 @@ export const Variants: React.FC = () => (
     <h3>destructive</h3>
     <div style={{ display: 'flex', margin: 16 }}>
       <Button variant="secondary-destructive"> Button</Button>
-      <Button variant="secondary-destructive" iconLeft={<Icon iconName="lock"/>}>
+      <Button variant="secondary-destructive" iconLeft={<Icon iconName="lock" />}>
         Icon left
       </Button>
-      <Button variant="secondary-destructive" iconRight={<Icon iconName="lock"/>}>
+      <Button variant="secondary-destructive" iconRight={<Icon iconName="lock" />}>
         Icon right
       </Button>
       <Button variant="secondary-destructive" iconButton>
         <Icon iconName="lock"></Icon>
       </Button>
       <Button variant="secondary-destructive" disabled>
-      Disabled
+        Disabled
       </Button>
     </div>
 
     <h2 className="tk-mt-5h">Tertiary</h2>
     <div style={{ display: 'flex', margin: 16 }}>
       <Button variant="tertiary">Button</Button>
-      <Button variant="tertiary" iconLeft={<Icon iconName="lock"/>}>
+      <Button variant="tertiary" iconLeft={<Icon iconName="lock" />}>
         Icon left
       </Button>
-      <Button variant="tertiary" iconRight={<Icon iconName="lock"/>}>
+      <Button variant="tertiary" iconRight={<Icon iconName="lock" />}>
         Icon right
       </Button>
       <Button variant="tertiary" loading>
@@ -105,40 +105,40 @@ export const Variants: React.FC = () => (
         <Icon iconName="lock"></Icon>
       </Button>
       <Button variant="tertiary" disabled>
-      Disabled
+        Disabled
       </Button>
     </div>
 
     <h3>destructive</h3>
     <div style={{ display: 'flex', margin: 16 }}>
       <Button variant="tertiary-destructive"> Button</Button>
-      <Button variant="tertiary-destructive" iconLeft={<Icon iconName="lock"/>}>
+      <Button variant="tertiary-destructive" iconLeft={<Icon iconName="lock" />}>
         Icon left
       </Button>
-      <Button variant="tertiary-destructive" iconRight={<Icon iconName="lock"/>}>
+      <Button variant="tertiary-destructive" iconRight={<Icon iconName="lock" />}>
         Icon right
       </Button>
       <Button variant="tertiary-destructive" iconButton>
         <Icon iconName="lock"></Icon>
       </Button>
       <Button variant="tertiary-destructive" disabled>
-      Disabled
+        Disabled
       </Button>
     </div>
     <h3>active</h3>
     <div style={{ display: 'flex', margin: 16 }}>
       <Button variant="tertiary-accent"> Button</Button>
-      <Button variant="tertiary-accent" iconLeft={<Icon iconName="lock"/>}>
+      <Button variant="tertiary-accent" iconLeft={<Icon iconName="lock" />}>
         Icon left
       </Button>
-      <Button variant="tertiary-accent" iconRight={<Icon iconName="lock"/>}>
+      <Button variant="tertiary-accent" iconRight={<Icon iconName="lock" />}>
         Icon right
       </Button>
       <Button variant="tertiary-accent" iconButton>
         <Icon iconName="lock"></Icon>
       </Button>
       <Button variant="tertiary-accent" disabled>
-      Disabled
+        Disabled
       </Button>
     </div>
   </div>
@@ -148,70 +148,70 @@ export const Sizes: React.FC = () => (
   <div className="button-storybook">
     <div style={{ display: 'flex', margin: 16 }}>
       <Button variant="primary"> Button</Button>
-      <Button variant="primary" iconLeft={<Icon iconName="lock"/>}>
-      Icon left
+      <Button variant="primary" iconLeft={<Icon iconName="lock" />}>
+        Icon left
       </Button>
-      <Button variant="primary" iconRight={<Icon iconName="lock"/>}>
-      Icon right 
+      <Button variant="primary" iconRight={<Icon iconName="lock" />}>
+        Icon right
       </Button>
       <Button variant="primary" loading>
-      Button
+        Button
       </Button>
       <Button variant="primary" iconButton>
         <Icon iconName="lock"></Icon>
       </Button>
       <Button variant="primary" disabled>
-      Disabled
+        Disabled
       </Button>
     </div>
     <div style={{ display: 'flex', margin: 16 }}>
       <Button variant="secondary"> Button</Button>
-      <Button variant="secondary"  iconLeft={<Icon iconName="lock"/>}>
-      Icon left
+      <Button variant="secondary" iconLeft={<Icon iconName="lock" />}>
+        Icon left
       </Button>
-      <Button variant="secondary"  iconRight={<Icon iconName="lock"/>}>
-      Icon right 
-        
+      <Button variant="secondary" iconRight={<Icon iconName="lock" />}>
+        Icon right
+
       </Button>
       <Button variant="secondary" loading>
-      Button
+        Button
       </Button>
       <Button variant="secondary" iconButton>
         <Icon iconName="lock"></Icon>
       </Button>
       <Button variant="secondary" disabled>
-      Disabled
+        Disabled
       </Button>
     </div>
     <div style={{ display: 'flex', margin: 16 }}>
       <Button variant="tertiary"> Button</Button>
-      <Button variant="tertiary" iconLeft={<Icon iconName="lock"/>}>
-      Icon left
+      <Button variant="tertiary" iconLeft={<Icon iconName="lock" />}>
+        Icon left
       </Button>
-      <Button variant="tertiary" iconRight={<Icon iconName="lock"/>}>
-      Icon right 
+      <Button variant="tertiary" iconRight={<Icon iconName="lock" />}>
+        Icon right
       </Button>
       <Button variant="tertiary" loading>
-      Button
+        Button
       </Button>
       <Button variant="tertiary" iconButton>
         <Icon iconName="lock"></Icon>
       </Button>
       <Button variant="tertiary" disabled>
-      Disabled
+        Disabled
       </Button>
     </div>
     <h3>Small</h3>
     <div style={{ display: 'flex', margin: 16 }}>
       <Button variant="primary" size="small" > Button</Button>
-      <Button variant="primary" size="small" iconLeft={<Icon iconName="lock"/>}>
-      Icon left
+      <Button variant="primary" size="small" iconLeft={<Icon iconName="lock" />}>
+        Icon left
       </Button>
-      <Button variant="primary" size="small" iconRight={<Icon iconName="lock"/>}>
-      Icon right
+      <Button variant="primary" size="small" iconRight={<Icon iconName="lock" />}>
+        Icon right
       </Button>
       <Button variant="primary" size="small" loading>
-      Button
+        Button
       </Button>
       <Button variant="primary" size="small" iconButton>
         <Icon iconName="lock"></Icon>
@@ -222,32 +222,32 @@ export const Sizes: React.FC = () => (
     </div>
     <div style={{ display: 'flex', margin: 16 }}>
       <Button variant="secondary" size="small"> Button</Button>
-      <Button variant="secondary" size="small" iconLeft={<Icon iconName="lock"/>}>
-      Icon left
+      <Button variant="secondary" size="small" iconLeft={<Icon iconName="lock" />}>
+        Icon left
       </Button>
-      <Button variant="secondary" size="small" iconRight={<Icon iconName="lock"/>}>
-      Icon right 
+      <Button variant="secondary" size="small" iconRight={<Icon iconName="lock" />}>
+        Icon right
       </Button>
       <Button variant="secondary" size="small" loading>
-      Button
+        Button
       </Button>
       <Button variant="secondary" size="small" iconButton>
         <Icon iconName="lock"></Icon>
       </Button>
       <Button variant="secondary" size="small" disabled>
-      Disabled
+        Disabled
       </Button>
     </div>
     <div style={{ display: 'flex', margin: 16 }}>
       <Button variant="tertiary" size="small">Button</Button>
-      <Button variant="tertiary" size="small" iconLeft={<Icon iconName="lock"/>}>
-      Icon left
+      <Button variant="tertiary" size="small" iconLeft={<Icon iconName="lock" />}>
+        Icon left
       </Button>
-      <Button variant="tertiary" size="small" iconRight={<Icon iconName="lock"/>}>
-      Icon right
+      <Button variant="tertiary" size="small" iconRight={<Icon iconName="lock" />}>
+        Icon right
       </Button>
       <Button variant="tertiary" size="small" loading>
-      Button
+        Button
       </Button>
       <Button variant="tertiary" size="small" iconButton>
         <Icon iconName="lock"></Icon>
@@ -259,32 +259,32 @@ export const Sizes: React.FC = () => (
     <h3>large</h3>
     <div style={{ display: 'flex', margin: 16 }}>
       <Button variant="primary" size="large"> Button</Button>
-      <Button variant="primary" size="large" iconLeft={<Icon iconName="lock"/>} >
-      Icon left
+      <Button variant="primary" size="large" iconLeft={<Icon iconName="lock" />} >
+        Icon left
       </Button>
-      <Button variant="primary" size="large" iconRight={<Icon iconName="lock"/>}> 
-      Icon right       
+      <Button variant="primary" size="large" iconRight={<Icon iconName="lock" />}>
+        Icon right
       </Button>
       <Button variant="primary" size="large" loading>
-      Button
+        Button
       </Button>
       <Button variant="primary" size="large" iconButton>
         <Icon iconName="lock"></Icon>
       </Button>
       <Button variant="primary" size="large" disabled>
-      Disabled
+        Disabled
       </Button>
     </div>
     <div style={{ display: 'flex', margin: 16 }}>
       <Button variant="secondary" size="large"> Button</Button>
-      <Button variant="secondary" size="large" iconLeft={<Icon iconName="lock"/>}>
-      Icon left
+      <Button variant="secondary" size="large" iconLeft={<Icon iconName="lock" />}>
+        Icon left
       </Button>
-      <Button variant="secondary" size="large" iconRight={<Icon iconName="lock"/>}>
-      Icon right 
+      <Button variant="secondary" size="large" iconRight={<Icon iconName="lock" />}>
+        Icon right
       </Button>
       <Button variant="secondary" size="large" loading>
-      Button
+        Button
       </Button>
       <Button variant="secondary" size="large" iconButton>
         <Icon iconName="lock"></Icon>
@@ -295,14 +295,14 @@ export const Sizes: React.FC = () => (
     </div>
     <div style={{ display: 'flex', margin: 16 }}>
       <Button variant="tertiary" size="large"> Button</Button>
-      <Button variant="tertiary" size="large" iconLeft={<Icon iconName="lock"/>}>
-      Icon left
+      <Button variant="tertiary" size="large" iconLeft={<Icon iconName="lock" />}>
+        Icon left
       </Button>
-      <Button variant="tertiary" size="large" iconRight={<Icon iconName="lock"/>}>
-      Icon right 
+      <Button variant="tertiary" size="large" iconRight={<Icon iconName="lock" />}>
+        Icon right
       </Button>
       <Button variant="tertiary" size="large" loading>
-      Button
+        Button
       </Button>
       <Button variant="tertiary" size="large" iconButton>
         <Icon iconName="lock"></Icon>


### PR DESCRIPTION
**Jira ticket**
https://perzoinc.atlassian.net/browse/APP-4649

**Changes**
Remove the breaking change on the Button component (impacting RTC team).
It removes the 'span' which was added in the Button Component to support the size of the button in "loading" state.
Another solution to support the size of the button is provided in this PR: Use transparent color and use an aria-label for the screenreaders.

**Demo**
<img width="876" alt="Screenshot 2021-10-28 at 16 01 46" src="https://user-images.githubusercontent.com/66668470/139271701-c2c5556c-04e8-4501-be7d-db89bbd21f58.png">

