### PR TITLE
APP-4603  Pass onCopy/onCut/onDrag on Dropdown component

### DIFF
--- a/spec/components/time-picker/TimePicker.spec.tsx
+++ b/spec/components/time-picker/TimePicker.spec.tsx
@@ -31,6 +31,9 @@ describe('TimePicker Component', () => {
       format: 'hh:mm:ss a',
       onBlur: jest.fn(),
       onChange: jest.fn(),
+      onCopy: jest.fn(),
+      onCut: jest.fn(),
+      onDrag: jest.fn(),
       onValidationChanged: jest.fn(),
       ...props,
     };
@@ -50,6 +53,9 @@ describe('TimePicker Component', () => {
     expect(wrapperPicker.prop('showRequired')).toBe(props.showRequired);
     expect(wrapperPicker.prop('name')).toBe(props.name);
     expect(wrapperPicker.prop('placeHolder')).toBe(props.placeholder);
+    expect(wrapperPicker.prop('onCopy')).toBe(props.onCopy);
+    expect(wrapperPicker.prop('onCut')).toBe(props.onCut);
+    expect(wrapperPicker.prop('onDrag')).toBe(props.onDrag);
   });
 
   it('should trigger onFocus', async () => {

--- a/src/components/date-picker/DatePicker.tsx
+++ b/src/components/date-picker/DatePicker.tsx
@@ -30,7 +30,6 @@ import { format as formatDate, isValid } from 'date-fns';
 
 import { ErrorMessages, HasValidationProps } from '../validation/interfaces';
 import { HasTooltipProps } from '../tooltip/interfaces';
-import { InputBaseProps, InputBasePropTypes } from '../input/TextComponent';
 import { MenuPortalProps } from '../dropdown/interfaces';
 
 // z-index: 4; equivalent to $z-index-tooltip
@@ -68,7 +67,7 @@ type DatePickerComponentProps = {
   /* The picker is open on render (not supported with menuPortalTarget) */
   showOverlay?: boolean;
   showRequired?: boolean;
-} & HasTooltipProps &
+} & React.HTMLProps<HTMLInputElement> & HasTooltipProps &
   HasValidationProps<Date> &
   MenuPortalProps;
 
@@ -84,7 +83,7 @@ type DatePickerComponentState = {
 };
 
 class DatePicker extends Component<
-  DatePickerComponentProps & InputBaseProps,
+  DatePickerComponentProps,
   DatePickerComponentState
 > {
   static defaultProps = {
@@ -129,8 +128,7 @@ class DatePicker extends Component<
     tooltip: PropTypes.string,
     tooltipCloseLabel: PropTypes.string,
     showRequired: PropTypes.bool,
-    showOverlay: PropTypes.bool,
-    ...InputBasePropTypes,
+    showOverlay: PropTypes.bool
   };
   refPicker = null;
   dayPickerInstance = null;
@@ -298,10 +296,10 @@ class DatePicker extends Component<
       if (scrollContainer) {
         const wheelEvent = EventListener.onwheel in document.createElement('div') ? EventListener.wheel : EventListener.mousewheel;
 
-        scrollContainer.addEventListener(EventListener.DOMMouseScroll,this.handleScrollParent); // older Firefox
-        scrollContainer.addEventListener(EventListener.touchmove,this.handleScrollParent); // mobile
+        scrollContainer.addEventListener(EventListener.DOMMouseScroll, this.handleScrollParent); // older Firefox
+        scrollContainer.addEventListener(EventListener.touchmove, this.handleScrollParent); // mobile
         scrollContainer.addEventListener(wheelEvent, this.handleScrollParent); // modern desktop
-        scrollContainer.addEventListener(EventListener.keydown,this.handleKeydownScrollParent);
+        scrollContainer.addEventListener(EventListener.keydown, this.handleKeydownScrollParent);
       }
     }
   }
@@ -318,10 +316,10 @@ class DatePicker extends Component<
         if (scrollContainer) {
           const wheelEvent = EventListener.onwheel in document.createElement('div') ? EventListener.wheel : EventListener.mousewheel;
 
-          scrollContainer.removeEventListener(EventListener.DOMMouseScroll,this.handleScrollParent);
-          scrollContainer.removeEventListener(EventListener.touchmove,this.handleScrollParent);
+          scrollContainer.removeEventListener(EventListener.DOMMouseScroll, this.handleScrollParent);
+          scrollContainer.removeEventListener(EventListener.touchmove, this.handleScrollParent);
           scrollContainer.removeEventListener(wheelEvent, this.handleScrollParent);
-          scrollContainer.removeEventListener(EventListener.keydown,this.handleKeydownScrollParent);
+          scrollContainer.removeEventListener(EventListener.keydown, this.handleKeydownScrollParent);
         }
       }
     }

--- a/src/components/dropdown/CustomRender.tsx
+++ b/src/components/dropdown/CustomRender.tsx
@@ -62,6 +62,9 @@ export const Input = (props: any) => {
   const inputAlwaysDisplayed = props?.selectProps?.inputAlwaysDisplayed;
   return <components.Input
     {...props}
+    onCopy={props?.selectProps?.onCopy}
+    onCut={props?.selectProps?.onCut}
+    onDrag={props?.selectProps?.onDrag}
     onKeyUp={props?.selectProps?.onKeyUp}  
     isHidden={inputAlwaysDisplayed ? !inputAlwaysDisplayed : false}
   />;

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -155,6 +155,9 @@ export class Dropdown<T = LabelValue> extends React.Component<
       name,
       noOptionMessage,
       placeHolder,
+      onCopy,
+      onCut,
+      onDrag,
       onFocus,
       onInputChange,
       onKeyDown,
@@ -229,6 +232,9 @@ export class Dropdown<T = LabelValue> extends React.Component<
           inputAlwaysDisplayed={inputAlwaysDisplayed}
           onChange={this.handleChange}
           onBlur={this.handleBlur}
+          onCopy={onCopy}
+          onCut={onCut}
+          onDrag={onDrag}
           onFocus={onFocus}
           onInputChange={onInputChange}
           onKeyDown={onKeyDown}

--- a/src/components/dropdown/interfaces.ts
+++ b/src/components/dropdown/interfaces.ts
@@ -164,7 +164,8 @@ export type DropdownProps<T> = {
     | React.FunctionComponent<TagRendererProps<T>>;
   /** Message to be display on the header of the menu list when searching by term */
   termSearchMessage?: ((term: string) => string) | string;
-} & MenuPortalProps &
+} & React.HTMLProps<HTMLInputElement> &
+  MenuPortalProps &
   HasTooltipProps &
   (MultiModeProps<T> | SingleModeProps<T>) &
   (AsyncProps<T> | SyncProps<T>);

--- a/src/components/time-picker/TimePicker.tsx
+++ b/src/components/time-picker/TimePicker.tsx
@@ -1,10 +1,9 @@
 import { Dropdown, DropdownOption } from '../dropdown';
-import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { Keys } from '../common/eventUtils';
 import { ErrorMessages } from '../validation/interfaces';
-import { DisabledTime, TimePickerProps } from './interfaces';
+import { DisabledTime, TimePickerProps, TimePickerPropTypes } from './interfaces';
 import {
   formatTimeISO,
   formatISOTimeToSeconds,
@@ -38,6 +37,9 @@ export const TimePicker: React.FC<TimePickerProps> = ({
   max,
   name,
   onChange,
+  onCopy,
+  onCut,
+  onDrag,
   onFocus,
   onValidationChanged,
   placeholder,
@@ -184,7 +186,7 @@ export const TimePicker: React.FC<TimePickerProps> = ({
     placeholder = format ? format : getUserFormat();
   }
 
-  const onFocusWrapped = (event: React.FocusEvent<HTMLElement>) => {
+  const onFocusWrapped = (event: React.FocusEvent<HTMLInputElement>) => {
     if (onFocus) {
       onFocus(event);
     }
@@ -199,8 +201,8 @@ export const TimePicker: React.FC<TimePickerProps> = ({
       iconName="recent"
       id={id}
       isDisabled={disabled}
-      isOptionDisabled={(time) => isTimeDisabled(time, disabledTimes)}
-      isOptionSelected={(time) =>
+      isOptionDisabled={(time: any) => isTimeDisabled(time, disabledTimes)}
+      isOptionSelected={(time: any) =>
         isTimeSelected(time, hours, minutes, seconds, disabledTimes)
       }
       inputAlwaysDisplayed={true}
@@ -222,6 +224,9 @@ export const TimePicker: React.FC<TimePickerProps> = ({
         // Called when the user select an option in the Dropdown menu
         setSelectedOption(option);
       }}
+      onCopy={onCopy}
+      onCut={onCut}
+      onDrag={onDrag}
       onFocus={onFocusWrapped}
       onKeyDown={(event) =>
         handleKeyDown(
@@ -257,29 +262,7 @@ export const TimePicker: React.FC<TimePickerProps> = ({
   );
 };
 
-TimePicker.propTypes = {
-  disabled: PropTypes.bool,
-  disabledTimes: PropTypes.array,
-  format: PropTypes.string,
-  id: PropTypes.string,
-  label: PropTypes.string,
-  max: PropTypes.string,
-  min: PropTypes.string,
-  menuPortalStyles: PropTypes.object,
-  menuPortalTarget: PropTypes.instanceOf(HTMLElement),
-  menuShouldBlockScroll: PropTypes.bool,
-  name: PropTypes.string,
-  onChange: PropTypes.func,
-  onFocus: PropTypes.func,
-  onValidationChanged: PropTypes.func,
-  placeholder: PropTypes.string,
-  showRequired: PropTypes.bool,
-  step: PropTypes.number,
-  strict: PropTypes.bool,
-  tooltip: PropTypes.string,
-  tooltipCloseLabel: PropTypes.string,
-  value: PropTypes.string
-};
+TimePicker.propTypes = TimePickerPropTypes;
 
 /**
  * Test if the input value raised an error to the Validation component

--- a/src/components/time-picker/interfaces.ts
+++ b/src/components/time-picker/interfaces.ts
@@ -1,3 +1,4 @@
+import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import { HasTooltipProps } from '../tooltip/interfaces';
 import { HasValidationProps } from '../validation/interfaces';
@@ -31,7 +32,6 @@ export type TimePickerProps = {
   max?: string;
   /** Identifies the time picker. */
   name?: string;
-  onFocus?: (event: React.FocusEvent<HTMLElement>) => void;
   /** If null, then it will use the time format. */
   placeholder?: string;
   /** The step interval in seconds to be used to define the suggested times (min: 600, max: 43200, default: 900).*/
@@ -41,6 +41,31 @@ export type TimePickerProps = {
   /** Date with ISO_8601 format (HH:mm:ss). */
   value?: string;
   showRequired?: boolean;
-} & MenuPortalProps &
+} & React.HTMLProps<HTMLInputElement> &
+  MenuPortalProps &
   HasValidationProps<TimePickerValue> &
   HasTooltipProps;
+
+export const TimePickerPropTypes = {
+  disabled: PropTypes.bool,
+  disabledTimes: PropTypes.array,
+  format: PropTypes.string,
+  id: PropTypes.string,
+  label: PropTypes.string,
+  max: PropTypes.string,
+  min: PropTypes.string,
+  menuPortalStyles: PropTypes.object,
+  menuPortalTarget: PropTypes.instanceOf(HTMLElement),
+  menuShouldBlockScroll: PropTypes.bool,
+  name: PropTypes.string,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  onValidationChanged: PropTypes.func,
+  placeholder: PropTypes.string,
+  showRequired: PropTypes.bool,
+  step: PropTypes.number,
+  strict: PropTypes.bool,
+  tooltip: PropTypes.string,
+  tooltipCloseLabel: PropTypes.string,
+  value: PropTypes.string,
+};


### PR DESCRIPTION
**Jira ticket**
https://perzoinc.atlassian.net/browse/APP-4603

**Changes**
-TimePicker: Pass the `onCopy`/`onCut`/`onDrag` props to the Dropdown component
-Dropdown: Apply `onCopy`/`onCut`/`onDrag` props on the Input if they are defined

(FYI, I had to use 'any' in the `isOptionDisabled` and `isOptionSelected` props because I got a TypeScript error. In a major UI-TK version, we will replace the `any` with the right type.)

**Demo**
In NEXUS, it fixes the prevent copy feature

https://user-images.githubusercontent.com/66668470/143472147-695f583a-0a2e-46b0-9834-35ea9abf2a6d.mov


