### PR TITLE
RTC-11877 - Not render a tooltip in TextEllipsis if tooltipProps.description or children are undefined

### DIFF
--- a/spec/components/text-ellipsis/TextEllipsis.spec.tsx
+++ b/spec/components/text-ellipsis/TextEllipsis.spec.tsx
@@ -7,24 +7,6 @@ import { TextEllipsis } from '../../../src/components';
 
 describe('TextEllipsis', () => {
 
-  it('should create a tooltip when tooltipOnEllipsis is true', () => {
-    const { container } = render(
-      <TextEllipsis rows={ 1 }>
-        { 'Really, really, really, really, really, long text that gets cut!' }
-      </TextEllipsis>
-    )
-    expect(container.querySelector('.tk-tooltip__wrapper')).toBeDefined()
-  });
-
-  it('should not create a tooltip when tooltipOnEllipsis is false', () => {
-    const { container } = render(
-      <TextEllipsis tooltipOnEllipsis={false}>
-        { 'Really, really, really, really, really, long text that gets cut!' }
-      </TextEllipsis>      
-    )
-    expect(container.querySelector('.tk-tooltip__wrapper')).toBeNull();
-  });
-
   it('should apply -webkit-line-clamp: 1 by default', () => {
     render(
       <TextEllipsis>
@@ -46,5 +28,45 @@ describe('TextEllipsis', () => {
     const element = screen.queryByText('Really, really, really, really, really, long text that gets cut!')
     expect(element.style['WebkitLineClamp']).toBe('2')
   })
+
+  describe('Tooltip', () => {
+
+    it('should create a tooltip when tooltipOnEllipsis is true', () => {
+      const { container } = render(
+        <TextEllipsis rows={ 1 }>
+          { 'Really, really, really, really, really, long text that gets cut!' }
+        </TextEllipsis>
+      )
+      expect(container.querySelector('.tk-tooltip__wrapper')).toBeDefined()
+    });
+  
+    it('should not create a tooltip when tooltipOnEllipsis is false', () => {
+      const { container } = render(
+        <TextEllipsis tooltipOnEllipsis={false}>
+          { 'Really, really, really, really, really, long text that gets cut!' }
+        </TextEllipsis>
+      )
+      expect(container.querySelector('.tk-tooltip__wrapper')).toBeNull();
+    });
+
+    it('should not create a tooltip when props.children and props.tooltipProps.description are not set', () => {
+      const { container } = render(
+        <TextEllipsis tooltipOnEllipsis={true}>
+          { null }
+        </TextEllipsis>
+      )
+      expect(container.querySelector('.tk-tooltip__wrapper')).toBeNull();
+    })
+
+    it('should create a tooltip when props.children is not set and props.tooltipProps.description is set', () => {
+      const { container } = render(
+        <TextEllipsis tooltipOnEllipsis={true} tooltipProps={{ description: 'Test' }}>
+          { null }
+        </TextEllipsis>
+      )
+      expect(container.querySelector('.tk-tooltip__wrapper')).toBeDefined();
+    })
+
+  });
 
 });

--- a/src/components/text-ellipsis/TextEllipsis.tsx
+++ b/src/components/text-ellipsis/TextEllipsis.tsx
@@ -48,12 +48,16 @@ export const TextEllipsis: React.FC<TextEllipsisProps> = ({
       { children }
     </span>)
   }
+
+  if(!tooltipProps?.description && !children) {
+    return null
+  }
   
   if(tooltipOnEllipsis) {
     return(
       <Tooltip
         {...tooltipProps}
-        description={ tooltipProps?.description ?? children as JSX.Element }
+        description={ tooltipProps?.description ?? (children as JSX.Element) }
         placement={ tooltipProps?.placement ?? 'top' }
         type={ tooltipProps?.type ?? 'tooltip' }
         visible={ tooltipProps?.visible ?? showTooltip }


### PR DESCRIPTION
If the child is undefined, the TextEllipsis returns an error because description cannot be empty for tooltip.