### PR TITLE
APP-4520 feat(dropdown): add size and variant prop

### DIFF
--- a/src/components/dropdown/CustomRender.tsx
+++ b/src/components/dropdown/CustomRender.tsx
@@ -133,7 +133,6 @@ export const Control = ({ children, selectProps, ...props }: any) => {
   const {iconName} = selectProps;
   return (<div>
     <components.Control {...props} className="tk-select__container">
-      {/* replacing tk-input__container by tk-select__container is a breaking change... but I don't want tk-input__container styles! */}
       {iconName && <Icon iconName={iconName} className="tk-input__icon" tabIndex={0}/>}
       {children}
     </components.Control>

--- a/src/components/dropdown/CustomRender.tsx
+++ b/src/components/dropdown/CustomRender.tsx
@@ -133,7 +133,7 @@ export const Control = ({ children, selectProps, ...props }: any) => {
   const {iconName} = selectProps;
   return (<div>
     <components.Control {...props} className="tk-select__container">
-      {/* todo remove tk-input__container by tk-select__container but it's a breaking change */}
+      {/* replacing tk-input__container by tk-select__container is a breaking change... but I don't want tk-input__container styles! */}
       {iconName && <Icon iconName={iconName} className="tk-input__icon" tabIndex={0}/>}
       {children}
     </components.Control>

--- a/src/components/dropdown/CustomRender.tsx
+++ b/src/components/dropdown/CustomRender.tsx
@@ -81,21 +81,20 @@ export const DefaultTagRenderer = (props: any) => {
   const TagRender = props.selectProps?.tagRenderer;
   const rendererProps = { remove: props.removeProps.onClick, data: props.data };
   return (<>
-    {TagRender ? 
+    {TagRender ?
       <div onMouseDown={stopPropagation}>
         <TagRender {...rendererProps} />
       </div>
       : <components.MultiValue {...props}>
-        <div onMouseDown={stopPropagation} className="tk-px-1" style={{display:'flex'} }>
-          <div className="tk-tag tk-pr-1">
+        <div onMouseDown={stopPropagation} style={{display:'flex', alignItems: 'center'} }>
+          <div className="tk-tag">
             {props.data?.label}
           </div>
-          <div>
-            <Icon iconName="cross" onClick={props.removeProps.onClick}/>
-          </div>
+          <Icon iconName="cross-round" onClick={props.removeProps.onClick}/>
         </div>
       </components.MultiValue>}
-  </>);
+  </>
+  );
 };
 
 export const MultiValueContainerOverride = ({ children, ...props }: any) => 
@@ -132,8 +131,9 @@ export const ClearIndicator = (props: any) =>
 
 export const Control = ({ children, selectProps, ...props }: any) => {
   const {iconName} = selectProps;
-  return (<div className="tk-input-group__header tk-pt-h">
-    <components.Control {...props} className="tk-input__container">
+  return (<div>
+    <components.Control {...props} className="tk-select__container">
+      {/* todo remove tk-input__container by tk-select__container but it's a breaking change */}
       {iconName && <Icon iconName={iconName} className="tk-input__icon" tabIndex={0}/>}
       {children}
     </components.Control>

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -23,6 +23,7 @@ import {
   LabelValue,
 } from './interfaces';
 import LabelTooltipDecorator from '../label-tooltip-decorator/LabelTooltipDecorator';
+import classNames from 'classnames';
 
 // css baseclass prefix
 const prefix = 'tk-select';
@@ -137,6 +138,7 @@ export class Dropdown<T = LabelValue> extends React.Component<
       autoScrollToCurrent,
       blurInputOnSelect,
       className,
+      defaultOptions,
       defaultValue,
       enableTermSearch,
       iconName,
@@ -151,6 +153,11 @@ export class Dropdown<T = LabelValue> extends React.Component<
       maxHeight,
       maxMenuHeight,
       menuIsOpen,
+      menuPlacement,
+      menuPortalStyles,
+      menuPortalTarget,
+      menuShouldBlockScroll,
+      menuShouldScrollIntoView,
       mode,
       name,
       noOptionMessage,
@@ -162,32 +169,20 @@ export class Dropdown<T = LabelValue> extends React.Component<
       onMenuOpen,
       onMenuClose,
       optionRenderer,
+      showRequired,
+      size,
+      tabSelectsValue,
       tagRenderer,
+      termSearchMessage,
       tooltip,
       tooltipCloseLabel,
-      showRequired,
-      tabSelectsValue,
-      termSearchMessage,
       value,
-      defaultOptions,
-      menuPlacement,
-      menuShouldScrollIntoView,
-      menuPortalStyles,
-      menuPortalTarget,
-      menuShouldBlockScroll,
+      variant,
       ...otherProps
     } = this.props;
 
     return (
-      <div className={className}>
-        <LabelTooltipDecorator
-          htmlFor={id}
-          label={label}
-          placement={'top'}
-          tooltip={tooltip}
-          tooltipCloseLabel={tooltipCloseLabel}
-          showRequired={showRequired}
-        />
+      <div className={classNames(className, `${prefix}-group`)}>
         <DropdownTag
           {...otherProps}
           styles={{
@@ -221,7 +216,7 @@ export class Dropdown<T = LabelValue> extends React.Component<
           defaultValue={defaultValue}
           id={id}
           name={name}
-          className={prefix}
+          className={classNames(prefix, {[`${prefix}--${variant}`]: variant}, {[`${prefix}--${size}`]: size})}
           closeMenuOnSelect={closeMenuOnSelect}
           classNamePrefix={prefix}
           value={value}
@@ -261,6 +256,14 @@ export class Dropdown<T = LabelValue> extends React.Component<
           menuPortalTarget={menuPortalTarget}
           menuShouldBlockScroll={menuShouldBlockScroll}
           menuShouldScrollIntoView={menuShouldScrollIntoView}
+        />
+        <LabelTooltipDecorator
+          htmlFor={id}
+          label={label}
+          placement={'top'}
+          tooltip={tooltip}
+          tooltipCloseLabel={tooltipCloseLabel}
+          showRequired={showRequired}
         />
       </div>
     );

--- a/src/components/dropdown/interfaces.ts
+++ b/src/components/dropdown/interfaces.ts
@@ -157,7 +157,7 @@ export type DropdownProps<T> = {
   /** Flag to show the label with a specific styling if the field is required */
   showRequired?: boolean;
   /** Size of the input */
-  size?: 'small' | 'medium' | 'large'; // todo: refactor
+  size?: /*'small' |*/ 'medium' | 'large';
   /** Select the currently focused option when the user presses tab */
   tabSelectsValue?: boolean;
   /** Custom component used to override the default appearance of the dropdown select input item/s */
@@ -167,7 +167,7 @@ export type DropdownProps<T> = {
   /** Message to be display on the header of the menu list when searching by term */
   termSearchMessage?: ((term: string) => string) | string;
   /** Color variant of the button*/
-  variant?: 'destructive'; // todo: default? nothing or is it primary?
+  variant?: 'destructive'; // todo: default value? nothing, or primary?
 } & MenuPortalProps &
   HasTooltipProps &
   (MultiModeProps<T> | SingleModeProps<T>) &

--- a/src/components/dropdown/interfaces.ts
+++ b/src/components/dropdown/interfaces.ts
@@ -156,6 +156,8 @@ export type DropdownProps<T> = {
   onTermSearch?: (option: SearchHeaderOption) => any;
   /** Flag to show the label with a specific styling if the field is required */
   showRequired?: boolean;
+  /** Size of the input */
+  size?: 'small' | 'medium' | 'large'; // todo: refactor
   /** Select the currently focused option when the user presses tab */
   tabSelectsValue?: boolean;
   /** Custom component used to override the default appearance of the dropdown select input item/s */
@@ -164,6 +166,8 @@ export type DropdownProps<T> = {
     | React.FunctionComponent<TagRendererProps<T>>;
   /** Message to be display on the header of the menu list when searching by term */
   termSearchMessage?: ((term: string) => string) | string;
+  /** Color variant of the button*/
+  variant?: 'destructive'; // todo: default? nothing or is it primary?
 } & MenuPortalProps &
   HasTooltipProps &
   (MultiModeProps<T> | SingleModeProps<T>) &

--- a/src/components/dropdown/interfaces.ts
+++ b/src/components/dropdown/interfaces.ts
@@ -156,7 +156,7 @@ export type DropdownProps<T> = {
   onTermSearch?: (option: SearchHeaderOption) => any;
   /** Flag to show the label with a specific styling if the field is required */
   showRequired?: boolean;
-  /** Size of the input */
+  /** Size of the dropdown */
   size?: /*'small' |*/ 'medium' | 'large';
   /** Select the currently focused option when the user presses tab */
   tabSelectsValue?: boolean;
@@ -166,8 +166,8 @@ export type DropdownProps<T> = {
     | React.FunctionComponent<TagRendererProps<T>>;
   /** Message to be display on the header of the menu list when searching by term */
   termSearchMessage?: ((term: string) => string) | string;
-  /** Color variant of the button*/
-  variant?: 'destructive'; // todo: default value? nothing, or primary?
+  /** Color variant of the dropdown */
+  variant?: 'destructive';
 } & MenuPortalProps &
   HasTooltipProps &
   (MultiModeProps<T> | SingleModeProps<T>) &

--- a/src/components/input/TextComponent.tsx
+++ b/src/components/input/TextComponent.tsx
@@ -42,7 +42,7 @@ type TextComponentProps = {
   showRequired?: boolean;
   /** When present, it specifies that the field is read-only. */
   readOnly?: boolean;
-  /** Size of the button */
+  /** Size of the input */
   size?: 'small' | 'medium';
   value?: string;
 } & HasTooltipProps &

--- a/stories/Dropdown.stories.tsx
+++ b/stories/Dropdown.stories.tsx
@@ -1,11 +1,23 @@
 import * as React from 'react';
-import { Dropdown, DropdownOption, Icon, LabelValue, OptionRendererProps, SearchHeaderOption, TagRendererProps } from '../src/components';
+import {
+  Dropdown,
+  DropdownOption,
+  Icon,
+  LabelValue,
+  OptionRendererProps,
+  SearchHeaderOption,
+  TagRendererProps,
+} from '../src/components';
 import { PortalTemplate } from './templates';
 
 const defaultOptions: LabelValue[] = [
   { label: 'Option 1', value: '1' },
   { label: 'Option 2', value: '2' },
-  { label: 'Option 3 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse elementum gravida neque, suscipit ornare ex pulvinar id. Etiam vitae erat at dolor pharetra suscipit. Donec at nunc malesuada', value: '3' },
+  {
+    label:
+      'Option 3 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse elementum gravida neque, suscipit ornare ex pulvinar id. Etiam vitae erat at dolor pharetra suscipit. Donec at nunc malesuada',
+    value: '3',
+  },
 ];
 
 interface Person {
@@ -38,7 +50,7 @@ const personSelectorOptions: DropdownOption<Person>[] = [
 
 // Function provided by the user to filter the options
 const filterDefaultOptions = async (inputValue: string) => {
-  return defaultOptions.filter(i =>
+  return defaultOptions.filter((i) =>
     i?.label?.toLowerCase().includes(inputValue?.toLowerCase())
   );
 };
@@ -48,7 +60,6 @@ const promiseOptions = (inputValue: string): Promise<DropdownOption<LabelValue>[
     setTimeout(() =>
       resolve(filterDefaultOptions(inputValue)), 1000);
   });
-
 
 const timeZoneOptions: DropdownOption<LabelValue>[] = [
   { label: '(GMT +03:00) Tanzania', value: '8' },
@@ -132,6 +143,38 @@ Default.args = {
   onTermSearch: onTermSearch,
   onChange: onChange
 };
+
+export const Sizes: React.FC = () => (
+  <>
+    <h4>Small</h4>
+    <div style={{ display: 'flex' }}>
+      <div style={{ width: '384px', marginRight: '32px' }}>
+        <Dropdown options={defaultOptions} size="small" />
+      </div>
+      <div style={{ width: '384px' }}>
+        <Dropdown options={defaultOptions} isMultiSelect size="small" />
+      </div>
+    </div>
+    <h4>Medium</h4>
+    <div style={{ display: 'flex' }}>
+      <div style={{ width: '384px', marginRight: '32px' }}>
+        <Dropdown options={defaultOptions} size="medium" />
+      </div>
+      <div style={{ width: '384px' }}>
+        <Dropdown options={defaultOptions} isMultiSelect size="medium" />
+      </div>
+    </div>
+    <h4>Large</h4>
+    <div style={{ display: 'flex' }}>
+      <div style={{ width: '384px', marginRight: '32px' }}>
+        <Dropdown options={defaultOptions} size="large" />
+      </div>
+      <div style={{ width: '384px' }}>
+        <Dropdown options={defaultOptions} isMultiSelect size="large" />
+      </div>
+    </div>
+  </>
+);
 
 export const Select: React.FC = () => (
   <div>

--- a/stories/Dropdown.stories.tsx
+++ b/stories/Dropdown.stories.tsx
@@ -15,7 +15,7 @@ const defaultOptions: LabelValue[] = [
   { label: 'Option 2', value: '2' },
   {
     label:
-      'Option 3 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse elementum gravida neque, suscipit ornare ex pulvinar id. Etiam vitae erat at dolor pharetra suscipit. Donec at nunc malesuada',
+    'Option 3 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse elementum gravida neque, suscipit ornare ex pulvinar id. Etiam vitae erat at dolor pharetra suscipit. Donec at nunc malesuada',
     value: '3',
   },
 ];
@@ -149,6 +149,7 @@ export const Variants: React.FC = () => (<>
   <Dropdown options={defaultOptions} />
   <h4>Destructive</h4>
   <Dropdown options={defaultOptions} variant="destructive" />
+  <div className="tk-py-5"/><div className="tk-py-5"/>
 </>
 );
 
@@ -181,6 +182,7 @@ export const Sizes: React.FC = () => (
         <Dropdown options={defaultOptions} isMultiSelect size="large" />
       </div>
     </div>
+    <div className="tk-py-5"/><div className="tk-py-5"/>
   </>
 );
 
@@ -215,7 +217,7 @@ export const Select: React.FC = () => (
     <p className="tk-mt-4">
       With <strong>isDisabled</strong>:
     </p>
-    <Dropdown options={defaultOptions} placeHolder="No option available" isDisabled label="Field label" />
+    <Dropdown options={defaultOptions} defaultValue={defaultOptions[0]} placeHolder="No option available" isDisabled label="Field label" />
     <p className="tk-mt-4">
       With <strong>iconName</strong> displays the specified icon on the left side of the dropdown:
     </p>

--- a/stories/Dropdown.stories.tsx
+++ b/stories/Dropdown.stories.tsx
@@ -97,7 +97,7 @@ const iconData: DropdownOption<Icon>[] = [
 const IconPickerTagRenderer = (props: TagRendererProps<Icon>) => {
   const { data, remove } = props;
   return (
-    <div>
+    <div style={{backgroundColor: 'rgba(0, 200, 0, 0.5)', borderRadius: '4px', margin: '2px', padding: '0 4px'}}>
       {data.displayName}
       <Icon className="tk-pl-1" iconName={data.displayName} />
       <Icon className="tk-ml-1" iconName="cross" onClick={remove} />
@@ -144,9 +144,17 @@ Default.args = {
   onChange: onChange
 };
 
+export const Variants: React.FC = () => (<>
+  <h4>Default color</h4>
+  <Dropdown options={defaultOptions} />
+  <h4>Destructive</h4>
+  <Dropdown options={defaultOptions} variant="destructive" />
+</>
+);
+
 export const Sizes: React.FC = () => (
   <>
-    <h4>Small</h4>
+    {/* <h4>Small</h4>
     <div style={{ display: 'flex' }}>
       <div style={{ width: '384px', marginRight: '32px' }}>
         <Dropdown options={defaultOptions} size="small" />
@@ -154,7 +162,7 @@ export const Sizes: React.FC = () => (
       <div style={{ width: '384px' }}>
         <Dropdown options={defaultOptions} isMultiSelect size="small" />
       </div>
-    </div>
+    </div> */}
     <h4>Medium</h4>
     <div style={{ display: 'flex' }}>
       <div style={{ width: '384px', marginRight: '32px' }}>
@@ -257,6 +265,17 @@ export const Select: React.FC = () => (
       filterFunction={filterFunction}
       tagRenderer={IconPickerRenderer}
       onTermSearch={onTermSearch}
+    />
+    <br/>
+    <Dropdown
+      options={iconData}
+      optionRenderer={IconPickerRenderer}
+      placeHolder="Select an icon.."
+      enableTermSearch
+      filterFunction={filterFunction}
+      tagRenderer={IconPickerRenderer}
+      onTermSearch={onTermSearch}
+      variant="destructive"
     />
 
     <p className="tk-mt-4">With <strong> tagRenderer </strong>prop you can customize the rendering of the selected item/s: </p>


### PR DESCRIPTION
## Ticket
https://perzoinc.atlassian.net/browse/APP-4520

## Description 
- Add size prop
- Add destructive prop
- Adjust keyboard navigation to the hint

## Comment
- I am having issue implementing size: small, the height should be 24px, but it is currently 32px (as medium) (--> not proposing small size for now) https://perzoinc.atlassian.net/browse/APP-4689

## Demo
![image](https://user-images.githubusercontent.com/56824367/142029884-b7c1c051-e55b-437e-a688-ee35e3bfa480.png)

![image](https://user-images.githubusercontent.com/56824367/142234278-7eb63ba3-8ee6-4c59-a374-95aedafae8cb.png)

![image](https://user-images.githubusercontent.com/56824367/142254629-99a5b494-00dd-40ee-9621-9b84da295427.png)


Styles: https://github.com/SymphonyPlatformSolutions/symphony-bdk-ui-toolkit-styles/pull/176

