### PR TITLE
fix: unwanted behaviour when the menu is not displayed

### DIFF
--- a/spec/components/dropdown-menu/DropdownMenu.spec.tsx
+++ b/spec/components/dropdown-menu/DropdownMenu.spec.tsx
@@ -36,6 +36,20 @@ describe('DropdownMenu', () => {
     expect(close).toHaveBeenCalled();
   });
 
+  it('shouldn\'t call onClose when clicking outside if show=false', () => {
+    const close = jest.fn();
+    render(
+      <div>
+        <div>some other div</div>
+        <DropdownMenu show={false} onClose={close}>
+          <DropdownMenuItem>Hello world</DropdownMenuItem>
+        </DropdownMenu>
+      </div>
+    ) ;
+    fireEvent.click(getByText(document.body, 'some other div'));
+    expect(close).not.toHaveBeenCalled();
+  });
+
   it('should close the menu when pressing esc key', () => {
     const close = jest.fn();
     render(

--- a/src/components/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/dropdown-menu/DropdownMenu.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import classNames from 'classnames';
-import {useEffect, useRef} from 'react';
-import {Keys} from '../common/eventUtils';
+import { Keys } from '../common/eventUtils';
 
 interface DropdownMenuProps extends React.HTMLProps<HTMLDivElement> {
   show?: boolean;
@@ -65,7 +65,7 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = ({children, className, 
     className,
   )
 
-  const menu = useRef(null);
+  const menu = useRef<HTMLDivElement>();
   const keyboardEventHandler = (e: KeyboardEvent) => {
     e.stopPropagation();
     if (e.key === Keys.ESC && onClose) {
@@ -80,15 +80,25 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = ({children, className, 
     }
   }
 
+  const removeListeners = useCallback(() => {
+    window.removeEventListener('keyup', keyboardEventHandler);
+    window.removeEventListener('click', mouseEventHandler);
+  }, [])
+
   useEffect(() => {
+    if (!show) {
+      removeListeners();
+      return;
+    }
+    
     window.addEventListener('keyup', keyboardEventHandler);
     window.addEventListener('click', mouseEventHandler);
 
-    return function cleanup() {
-      window.removeEventListener('keyup', keyboardEventHandler);
-      window.removeEventListener('click', mouseEventHandler);
+    return () => {
+      removeListeners()
     }
-  })
+  }, [show, removeListeners])
+  
   return show && (
     <div {...rest} className={classes} ref={menu}>
       {children}


### PR DESCRIPTION
For the need of [this CES ticket](https://perzoinc.atlassian.net/browse/CES-5147), I need to replace our DropDownMenu with the one from the UI Toolkit.

When implementing it, I found an issue because event listener `click` triggered the `mouseEventHandler` event for each click every where on the page **even if the menu is not open**.

So, when you click on a button that should open the menu, the `close()` is automatically triggered in the same time: so we can't open the menu.

I've just added a watch on `show` property in order to skip event listeners.
In short:
- `show=false`: we don't need to listen events
- `show=true`: we need to listen events