### PR TITLE
APP-4734 - Omitting the onChange props from React.HTMLProps<HTMLInputElements>

### DIFF
--- a/src/components/dropdown/interfaces.ts
+++ b/src/components/dropdown/interfaces.ts
@@ -164,7 +164,7 @@ export type DropdownProps<T> = {
     | React.FunctionComponent<TagRendererProps<T>>;
   /** Message to be display on the header of the menu list when searching by term */
   termSearchMessage?: ((term: string) => string) | string;
-} & React.HTMLProps<HTMLInputElement> &
+} & Omit<React.HTMLProps<HTMLInputElement>, 'onChange'> &
   MenuPortalProps &
   HasTooltipProps &
   (MultiModeProps<T> | SingleModeProps<T>) &


### PR DESCRIPTION
https://perzoinc.atlassian.net/browse/APP-4734 - See ticket for more details

After this PR - https://github.com/SymphonyPlatformSolutions/symphony-bdk-ui-toolkit-components/pull/308 - we got two interfaces for `onChange` in `Dropdown`. One which was the original one and one from `React.HTMLProps<HTMLInputElement>`. I looked at the event and it's more in line with the other one + we would keep backwards compatibility.