### PR TITLE
Replace NPM commands by Yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "clean": "rm -rf dist",
     "dedupe": "yarn-deduplicate",
     "init": "mkdir dist",
-    "prebuild": "npm run clean && npm run init",
+    "prebuild": "yarn run clean && yarn run init",
     "build": "tsc",
     "lint": "eslint --ext .ts,.tsx,.js,.jsx ./",
     "lint-fix": "eslint --ext .ts,.tsx,.js,.jsx ./ --fix",

--- a/publish.sh
+++ b/publish.sh
@@ -5,7 +5,7 @@ function executePublish {
     cp package.json dist/
     cp README.md dist/
     cd dist
-    npm publish --access public
+    yarn publish --access public
     cd ..
     git add package.json
     git config --global user.email "$GIT_USEREMAIL"
@@ -17,7 +17,7 @@ function executePublish {
 # Set version
 function setVersion {
     echo "Found tag, setting version to $CIRCLE_TAG"
-    npm --no-git-tag-version version ${CIRCLE_TAG//v}
+    yarn --no-git-tag-version version ${CIRCLE_TAG//v}
 }
 
 # Version and publish logic


### PR DESCRIPTION
**Changes**
Replace NPM commands by Yarn because it's a pre-requisite to merge UI-TK repositories.