### PR TITLE
APP-4755 Fix overlapping interfaces for the value property

### DIFF
--- a/src/components/date-picker/DatePicker.tsx
+++ b/src/components/date-picker/DatePicker.tsx
@@ -30,7 +30,7 @@ import { format as formatDate, isValid } from 'date-fns';
 
 import { ErrorMessages, HasValidationProps } from '../validation/interfaces';
 import { HasTooltipProps } from '../tooltip/interfaces';
-import { MenuPortalProps } from '../dropdown/interfaces';
+import { HTMLInputProps, MenuPortalProps } from '../dropdown/interfaces';
 
 // z-index: 4; equivalent to $z-index-tooltip
 const DatePickerContainer = styled.div`
@@ -68,7 +68,8 @@ type DatePickerComponentProps = {
   /* The picker is open on render (not supported with menuPortalTarget) */
   showOverlay?: boolean;
   showRequired?: boolean;
-} & React.HTMLProps<HTMLInputElement> & HasTooltipProps &
+} & HTMLInputProps &
+  HasTooltipProps &
   HasValidationProps<Date> &
   MenuPortalProps;
 

--- a/src/components/dropdown/interfaces.ts
+++ b/src/components/dropdown/interfaces.ts
@@ -7,6 +7,11 @@ export interface OptionRendererProps<T> {
   data: T;
 }
 
+export type HTMLInputProps = Omit<
+  React.HTMLProps<HTMLInputElement>,
+  'onChange' | 'value'
+>;
+
 export interface TagRendererProps<T> extends OptionRendererProps<T> {
   remove: () => any;
 }
@@ -170,7 +175,7 @@ export type DropdownProps<T> = {
   termSearchMessage?: ((term: string) => string) | string;
   /** Color variant of the dropdown */
   variant?: 'destructive';
-} & Omit<React.HTMLProps<HTMLInputElement>, 'onChange'> &
+} & HTMLInputProps &
   MenuPortalProps &
   HasTooltipProps &
   (MultiModeProps<T> | SingleModeProps<T>) &

--- a/src/components/time-picker/interfaces.ts
+++ b/src/components/time-picker/interfaces.ts
@@ -2,7 +2,7 @@ import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import { HasTooltipProps } from '../tooltip/interfaces';
 import { HasValidationProps } from '../validation/interfaces';
-import { MenuPortalProps } from '../dropdown/interfaces';
+import { HTMLInputProps, MenuPortalProps } from '../dropdown/interfaces';
 
 export type TimePickerValue = string;
 
@@ -42,7 +42,7 @@ export type TimePickerProps = {
   value?: string;
   showRequired?: boolean;
   helperText?: string;
-} & React.HTMLProps<HTMLInputElement> &
+} & HTMLInputProps &
   MenuPortalProps &
   HasValidationProps<TimePickerValue> &
   HasTooltipProps;


### PR DESCRIPTION
**Jira ticket**
https://perzoinc.atlassian.net/browse/APP-4755

**Changes**
A regression was introduced with PR #330. The 'value' prop type was overlapped by the HTMLInput interface.

**Before fix**
![Screenshot 2021-12-20 at 16 36 07](https://user-images.githubusercontent.com/66668470/146793003-a33aa825-4f14-41ff-a893-e48beb882c21.png)

**After fix:**
![Screenshot 2021-12-20 at 16 35 11](https://user-images.githubusercontent.com/66668470/146793071-dfed3856-1b85-4aa8-bfae-80f5df3c4c7d.png)

