### PR TITLE
APP-4654 feat(SelectionInput): accept node as label

### DIFF
--- a/spec/components/selection/SelectionInput.spec.tsx
+++ b/spec/components/selection/SelectionInput.spec.tsx
@@ -1,4 +1,6 @@
 import { mount, shallow } from 'enzyme';
+import { render } from '@testing-library/react';
+
 import * as React from 'react';
 import SelectionTypes from '../../../src/components/selection/SelectionTypes';
 
@@ -47,6 +49,22 @@ describe('SelectionInput Component', () => {
       expect(wrapper.find('input').prop('name')).toEqual(props.name);
       expect(wrapper.find('input').prop('value')).toEqual(props.value);
     });
+
+
+    it.each([['string', 'lorem ipsum', 'lorem ipsum'], ['node', <>bold text should display between the quotes &apos;<b>BOLD</b>&apos;</>, 'BOLD']])(
+      'render a Radio with "%s" label',
+      (title, label, expected) => {
+        const props = {
+          type: SelectionTypes.RADIO,
+          name: 'SelectionInput-test-name',
+          value: 'SelectionInput-test-value',
+          label
+        }
+  
+        const { getByText } = render(<SelectionInput {...props}/>);
+        expect(getByText(expected)).toBeInTheDocument();
+      }
+    )
 
     it('render a Switch with default props and initial value', () => {
       const props = {

--- a/src/components/selection/SelectionInput.tsx
+++ b/src/components/selection/SelectionInput.tsx
@@ -12,7 +12,7 @@ import { HasValidationProps } from '../validation/interfaces';
 interface SelectionInputProps {
   id?: string;
   name: string;
-  label?: string;
+  label?: string | React.ReactNode;
   labelPlacement?: LabelPlacements;
   value: string;
   status?: SelectionStatus;
@@ -196,7 +196,7 @@ const SelectionInput: React.FC<SelectionInputPropsWithType> = ({
 const SelectionInputPropTypes = {
   id: PropTypes.string,
   name: PropTypes.string.isRequired,
-  label: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
   labelPlacement: PropTypes.oneOf(Object.values(LabelPlacements)),
   value: PropTypes.string.isRequired,
   status: PropTypes.oneOf(Object.values(SelectionStatus)),


### PR DESCRIPTION
Prevent to have the following warning when passing a node to the label prop
```
"Warning: Failed prop type: Invalid prop `label` of type `object` supplied to `Checkbox`, expected `string`.
```