### PR TITLE
feat(input): add a classname to the hint to be more flexible

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@popperjs/core": "^2.4.4",
     "@seznam/compose-react-refs": "^1.0.6",
-    "@symphony-ui/uitoolkit-styles": "^3.0.0",
+    "@symphony-ui/uitoolkit-styles": "^3.0.2",
     "@types/classnames": "^2.2.10",
     "classnames": "^2.2.6",
     "date-fns": "^2.16.1",

--- a/spec/components/input/InputDecorator.spec.tsx
+++ b/spec/components/input/InputDecorator.spec.tsx
@@ -66,13 +66,6 @@ describe('InputDecorator Component', () => {
       ).toThrowError();
       spy.mockRestore();
     });
-    it('throw an error when rendering no children', () => {
-      const spy = jest.spyOn(console, 'error').mockImplementation(() => {
-        return;
-      });
-      expect(() => render(<InputDecorator></InputDecorator>)).toThrowError();
-      spy.mockRestore();
-    });
     it('throw an error when rendering too many children', () => {
       const spy = jest.spyOn(console, 'error').mockImplementation(() => {
         return;

--- a/src/components/input/InputDecorator.tsx
+++ b/src/components/input/InputDecorator.tsx
@@ -26,7 +26,7 @@ const InputDecoratorPropTypes = {
 type InputDecoratorProps = {
   rightDecorators?: JSX.Element | JSX.Element[];
   className?: string;
-  children: React.ReactElement;
+  children?: React.ReactElement;
 } & LabelTooltipDecoratorProps &
   HasValidationProps<string>;
 
@@ -46,15 +46,13 @@ const InputDecorator: React.FC<InputDecoratorProps> = ({
 }) => {
   let child;
 
-  if (React.Children.count(children) === 0) {
-    throw new Error('The Input decorator requires one child component.');
-  } else if (React.Children.count(children) > 1) {
+  if (React.Children.count(children) > 1) {
     throw new Error(
       `The Input decorator can wrap only one component. Found: ${React.Children.count(
         children
       )}`
     );
-  } else {
+  } else if (React.Children.count(children) === 1) {
     child = React.Children.only(children);
     if (child?.type !== 'input') {
       throw new Error(

--- a/src/components/label-tooltip-decorator/LabelTooltipDecorator.tsx
+++ b/src/components/label-tooltip-decorator/LabelTooltipDecorator.tsx
@@ -53,6 +53,7 @@ const LabelTooltipDecorator: React.FC<LabelTooltipDecoratorProps> = ({
             placement={placement || 'top'}
           >
             <Icon
+              className="tk-input-group__hint"
               iconName="info-round"
               onClick={() => setShowTooltip(!showTooltip)}
               onKeyDown={(event) => (event.key === 'Enter') && setShowTooltip(!showTooltip)}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2432,10 +2432,10 @@
     resolve-from "^5.0.0"
     store2 "^2.12.0"
 
-"@symphony-ui/uitoolkit-styles@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@symphony-ui/uitoolkit-styles/-/uitoolkit-styles-3.0.0.tgz#2aa70e2fa31e92eebb994cb66f4040907bfc7b67"
-  integrity sha512-WeTq4meCIHF/cUE3WjvO0ajP99bs5zBPag6XvDGtkFtmObmqUfbkdrcKplIYS+ZiGsKa3moRs/gLWfaqkN8+vw==
+"@symphony-ui/uitoolkit-styles@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@symphony-ui/uitoolkit-styles/-/uitoolkit-styles-3.0.2.tgz#d1d83c67b67f6f5a082d5ee6ea453c9a94a8cce9"
+  integrity sha512-cXbg8ZoK4+utT94zqLofMb7zLkKUM9igxxbRi/vuZA5dunIWrbJJfCO+UH++bRI9oeDMwIpny23ys+ztGMebiQ==
 
 "@testing-library/dom@^7.28.1", "@testing-library/dom@^7.29.0":
   version "7.30.4"


### PR DESCRIPTION
## Description
See description here for more context: https://github.com/SymphonyPlatformSolutions/symphony-bdk-ui-toolkit-components/pull/391

- Add a classname to the hint, so the style can decorate it and be independente of the icon

Bonus
- Remove mandatory `child` in the `InputDecorator`